### PR TITLE
Revert to zod 3, fix error handling from mcp server to client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "dotenv": "^17.2.1",
-        "zod": "^4.0.10"
+        "zod": "^3.25.76"
       },
       "bin": {
         "rollbar-mcp-server": "build/index.js"
@@ -255,15 +255,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
@@ -2669,9 +2660,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.10.tgz",
-      "integrity": "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.1",
     "dotenv": "^17.2.1",
-    "zod": "^4.0.10"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/src/tools/get-deployments.ts
+++ b/src/tools/get-deployments.ts
@@ -15,47 +15,29 @@ export function registerGetDeploymentsTool(server: McpServer) {
         .describe("Number of Rollbar deployments to retrieve"),
     },
     async ({ limit }) => {
-      try {
-        const deploysUrl = `${ROLLBAR_API_BASE}/deploys?limit=${limit}`;
-        const deploysResponse =
-          await makeRollbarRequest<RollbarApiResponse<RollbarDeployResponse>>(
-            deploysUrl,
-          );
-        console.error(deploysResponse);
+      const deploysUrl = `${ROLLBAR_API_BASE}/deploys?limit=${limit}`;
+      const deploysResponse =
+        await makeRollbarRequest<RollbarApiResponse<RollbarDeployResponse>>(
+          deploysUrl,
+        );
 
-        if (!deploysResponse || deploysResponse.err !== 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Failed to retrieve deployments.`,
-              },
-            ],
-          };
-        }
-
-        const deployItem = deploysResponse.result;
-        console.error("Deployments response:", deployItem);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(deployItem, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        console.error("Error in get-deployments tool:", error);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error retrieving deployment details: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
+      if (deploysResponse.err !== 0) {
+        const errorMessage =
+          deploysResponse.message ||
+          `Unknown error (code: ${deploysResponse.err})`;
+        throw new Error(`Rollbar API returned error: ${errorMessage}`);
       }
+
+      const deployments = deploysResponse.result;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(deployments, null, 2),
+          },
+        ],
+      };
     },
   );
 }

--- a/src/tools/get-item-details.ts
+++ b/src/tools/get-item-details.ts
@@ -16,83 +16,60 @@ export function registerGetItemDetailsTool(server: McpServer) {
       counter: z.number().int().describe("Rollbar item counter"),
     },
     async ({ counter }) => {
-      try {
-        // Redirects are followed, so we get an item response from the counter request
-        const counterUrl = `${ROLLBAR_API_BASE}/item_by_counter/${counter}`;
-        const itemResponse =
-          await makeRollbarRequest<RollbarApiResponse<RollbarItemResponse>>(
-            counterUrl,
-          );
-        console.error(itemResponse);
+      // Redirects are followed, so we get an item response from the counter request
+      const counterUrl = `${ROLLBAR_API_BASE}/item_by_counter/${counter}`;
+      const itemResponse =
+        await makeRollbarRequest<RollbarApiResponse<RollbarItemResponse>>(
+          counterUrl,
+        );
 
-        if (!itemResponse || itemResponse.err !== 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Failed to retrieve item details for counter ${counter}.`,
-              },
-            ],
-          };
-        }
+      if (itemResponse.err !== 0) {
+        const errorMessage =
+          itemResponse.message || `Unknown error (code: ${itemResponse.err})`;
+        throw new Error(`Rollbar API returned error: ${errorMessage}`);
+      }
 
-        const item = itemResponse.result;
+      const item = itemResponse.result;
 
-        // Use the complete item data
-        const formattedData = item;
+      const occurrenceUrl = `${ROLLBAR_API_BASE}/instance/${item.last_occurrence_id}`;
+      const occurrenceResponse =
+        await makeRollbarRequest<RollbarApiResponse<RollbarOccurrenceResponse>>(
+          occurrenceUrl,
+        );
 
-        const occurrenceUrl = `${ROLLBAR_API_BASE}/instance/${item.last_occurrence_id}`;
-        console.error(`Fetching occurrence details from: ${occurrenceUrl}`);
-        const occurrenceResponse =
-          await makeRollbarRequest<
-            RollbarApiResponse<RollbarOccurrenceResponse>
-          >(occurrenceUrl);
-        console.error("Occurrence response:", occurrenceResponse);
-
-        if (!occurrenceResponse || occurrenceResponse.err !== 0) {
-          // We got the item but failed to get occurrence, return just the item data
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify(formattedData, null, 2),
-              },
-            ],
-          };
-        }
-
-        const occurrence = occurrenceResponse.result;
-
-        // Remove the metadata section from occurrence.data to avoid exposing sensitive information
-        if (occurrence.data && occurrence.data.metadata) {
-          delete occurrence.data.metadata;
-        }
-
-        // Combine item and occurrence data
-        const responseData = {
-          ...formattedData,
-          occurrence: occurrence,
-        };
-
+      if (occurrenceResponse.err !== 0) {
+        // We got the item but failed to get occurrence, return just the item data
         return {
           content: [
             {
               type: "text",
-              text: JSON.stringify(responseData, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        console.error("Error in get-item-details tool:", error);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error retrieving item details: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify(item, null, 2),
             },
           ],
         };
       }
+
+      const occurrence = occurrenceResponse.result;
+
+      // Remove the metadata section from occurrence.data to avoid exposing sensitive information
+      if (occurrence.data && occurrence.data.metadata) {
+        delete occurrence.data.metadata;
+      }
+
+      // Combine item and occurrence data
+      const responseData = {
+        ...item,
+        occurrence: occurrence,
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(responseData, null, 2),
+          },
+        ],
+      };
     },
   );
 }

--- a/src/tools/get-top-items.ts
+++ b/src/tools/get-top-items.ts
@@ -15,47 +15,29 @@ export function registerGetTopItemsTool(server: McpServer) {
         .describe("Environment name (default: production)"),
     },
     async ({ environment }) => {
-      try {
-        const reportUrl = `${ROLLBAR_API_BASE}/reports/top_active_items?hours=24&environments=${environment}&sort=occurrences`;
-        const reportResponse =
-          await makeRollbarRequest<RollbarApiResponse<RollbarTopItemResponse>>(
-            reportUrl,
-          );
-        console.error(reportResponse);
+      const reportUrl = `${ROLLBAR_API_BASE}/reports/top_active_items?hours=24&environments=${environment}&sort=occurrences`;
+      const reportResponse =
+        await makeRollbarRequest<RollbarApiResponse<RollbarTopItemResponse>>(
+          reportUrl,
+        );
 
-        if (!reportResponse || reportResponse.err !== 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Failed to retrieve top item data.`,
-              },
-            ],
-          };
-        }
-
-        const itemItem = reportResponse.result;
-        console.error("Top items response:", itemItem);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(itemItem, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        console.error("Error in get-topitems tool:", error);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error retrieving top items details: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
+      if (reportResponse.err !== 0) {
+        const errorMessage =
+          reportResponse.message ||
+          `Unknown error (code: ${reportResponse.err})`;
+        throw new Error(`Rollbar API returned error: ${errorMessage}`);
       }
+
+      const topItems = reportResponse.result;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(topItems, null, 2),
+          },
+        ],
+      };
     },
   );
 }

--- a/src/tools/get-version.ts
+++ b/src/tools/get-version.ts
@@ -16,47 +16,29 @@ export function registerGetVersionTool(server: McpServer) {
         .describe("Environment name (default: production)"),
     },
     async ({ version, environment }) => {
-      try {
-        const versionsUrl = `${ROLLBAR_API_BASE}/versions/${version}?environment=${environment}`;
-        const versionsResponse =
-          await makeRollbarRequest<RollbarApiResponse<RollbarVersionsResponse>>(
-            versionsUrl,
-          );
-        console.error(versionsResponse);
+      const versionsUrl = `${ROLLBAR_API_BASE}/versions/${version}?environment=${environment}`;
+      const versionsResponse =
+        await makeRollbarRequest<RollbarApiResponse<RollbarVersionsResponse>>(
+          versionsUrl,
+        );
 
-        if (!versionsResponse || versionsResponse.err !== 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `Failed to retrieve version data.`,
-              },
-            ],
-          };
-        }
-
-        const versionItem = versionsResponse.result;
-        console.error("Versions response:", versionItem);
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(versionItem, null, 2),
-            },
-          ],
-        };
-      } catch (error) {
-        console.error("Error in get-versions tool:", error);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error retrieving versions details: ${error instanceof Error ? error.message : String(error)}`,
-            },
-          ],
-        };
+      if (versionsResponse.err !== 0) {
+        const errorMessage =
+          versionsResponse.message ||
+          `Unknown error (code: ${versionsResponse.err})`;
+        throw new Error(`Rollbar API returned error: ${errorMessage}`);
       }
+
+      const versionData = versionsResponse.result;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(versionData, null, 2),
+          },
+        ],
+      };
     },
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
 export interface RollbarApiResponse<T> {
   err: number;
   result: T;
+  message?: string;
 }
 
 export interface RollbarItemResponse {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,21 +1,38 @@
 import { ROLLBAR_ACCESS_TOKEN, USER_AGENT } from "../config.js";
 
 // Helper function for making Rollbar API requests
-export async function makeRollbarRequest<T>(url: string): Promise<T | null> {
+export async function makeRollbarRequest<T>(url: string): Promise<T> {
+  if (!ROLLBAR_ACCESS_TOKEN) {
+    throw new Error("ROLLBAR_ACCESS_TOKEN environment variable is not set");
+  }
+
   const headers = {
     "User-Agent": USER_AGENT,
-    "X-Rollbar-Access-Token": ROLLBAR_ACCESS_TOKEN as string,
+    "X-Rollbar-Access-Token": ROLLBAR_ACCESS_TOKEN,
     Accept: "application/json",
   };
 
-  try {
-    const response = await fetch(url, { headers });
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    let errorMessage = `Rollbar API error: ${response.status} ${response.statusText}`;
+
+    // Try to parse error message from response
+    try {
+      const errorJson = JSON.parse(errorText) as { message?: string };
+      if (errorJson.message) {
+        errorMessage = `Rollbar API error: ${errorJson.message}`;
+      }
+    } catch {
+      // If not JSON, include the raw text if it's short
+      if (errorText && errorText.length < 200) {
+        errorMessage += ` - ${errorText}`;
+      }
     }
-    return (await response.json()) as T;
-  } catch (error) {
-    console.error("Error making Rollbar API request:", error);
-    return null;
+
+    throw new Error(errorMessage);
   }
+
+  return (await response.json()) as T;
 }


### PR DESCRIPTION
- Revert to zod 3 (4 is incompatible with latest modelcontextprotocol/sdk)
- Simplifying and fix error handling, so that server errors are properly transmitted to the client