### PR TITLE
Add trunction and max_size arg for occurrence data in get-item-details

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This MCP server implementes the `stdio` server type, which means your AI tool (e
 
 ### Tools
 
-`get-item-details(counter)`: Given an item number, fetch the item details and last occurrence details. Example prompt: `Diagnose the root cause of Rollbar item #123456`
+`get-item-details(counter, max_tokens?)`: Given an item number, fetch the item details and last occurrence details. Supports an optional `max_tokens` parameter (default: 20000) to automatically truncate large occurrence responses. Example prompt: `Diagnose the root cause of Rollbar item #123456`
 
 `get-deployments(limit)`: List deploy data for the given project. Example prompt: `List the last 5 deployments` or `Are there any failed deployments?`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "rollbar-mcp-server",
-  "version": "0.0.1",
+  "name": "@rollbar/mcp-server",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rollbar-mcp-server",
-      "version": "0.0.1",
+      "name": "@rollbar/mcp-server",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",
         "dotenv": "^17.2.1",
+        "rollbar": "^3.0.0-alpha.2",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -27,6 +28,9 @@
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.31.0",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1184,6 +1188,28 @@
         "win32"
       ]
     },
+    "node_modules/@rrweb/record": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/record/-/record-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-WbzcybTEqT+cKkOnzYiyaAYvNzAIxTK9f8qNLNOG9lOqWsmi+qu/W7CEdxHmfjlfgXGw/f7bxGZggAWVaizKqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.18",
+        "rrweb": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -1193,6 +1219,12 @@
       "dependencies": {
         "@types/deep-eql": "*"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -1632,6 +1664,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1742,12 +1780,27 @@
         "js-tokens": "^9.0.1"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -1922,6 +1975,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/console-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.3.0.tgz",
+      "integrity": "sha512-w+JSDZS7XML43Xnwo2x5O5vxB0ID7T5BdqDtyqT6uiCAX2kZAgcWxNaGqT97tZfSHzfOcvrfsDAodKcJ3UvnXQ==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -2084,6 +2143,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-define-property": {
@@ -3123,6 +3191,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3320,6 +3394,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3330,7 +3410,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3548,7 +3627,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -3577,7 +3655,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3723,6 +3800,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3743,6 +3826,28 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rollbar": {
+      "version": "3.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-3.0.0-alpha.2.tgz",
+      "integrity": "sha512-U4SFjbbDm1v70H42EyHBKtoKMIDY5an0v5DswFHmP0dH2xUzzqWp7/U7j/x0otrN9HKBp143KCady7wcX3621Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/record": "^2.0.0-alpha.18",
+        "async": "~3.2.3",
+        "console-polyfill": "0.3.0",
+        "error-stack-parser": "^2.0.4",
+        "json-stringify-safe": "~5.0.0",
+        "lru-cache": "~2.2.1",
+        "request-ip": "~3.3.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "node_modules/rollbar/node_modules/lru-cache": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+      "integrity": "sha512-Q5pAgXs+WEAfoEdw2qKQhNFFhMoFMTYqRVKKUMnzuiR7oKFHS7fWo848cPcTKw+4j/IdN17NyzdhVKgabFV0EA==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.45.1",
@@ -3798,6 +3903,40 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/rrdom": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.0.0-alpha.18",
+        "@rrweb/utils": "^2.0.0-alpha.18",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.0.0-alpha.18",
+        "rrweb-snapshot": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
+      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
       }
     },
     "node_modules/run-parallel": {
@@ -4019,11 +4158,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4034,6 +4181,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.1",
     "dotenv": "^17.2.1",
+    "rollbar": "^3.0.0-alpha.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/utils/truncation.ts
+++ b/src/utils/truncation.ts
@@ -1,0 +1,37 @@
+import { createRequire } from "module";
+
+// Import rollbar's truncation module using CommonJS require
+const require = createRequire(import.meta.url);
+
+// Define types for the rollbar truncation module
+interface RollbarTruncation {
+  truncate: (
+    data: any,
+    jsonBackup: (obj: any) => string,
+    maxBytes: number,
+  ) => { value: string };
+}
+
+const truncation = require("rollbar/src/truncation") as RollbarTruncation;
+
+// Token estimation constants
+const CHARS_PER_TOKEN = 4; // Rough estimate: 1 token ≈ 4 characters
+
+/**
+ * Truncates an occurrence to fit within token limit
+ * @param occurrence - The occurrence to truncate (like a 'payload' in rollbar.js; has a top-level 'data' key)
+ * @param maxTokens - Maximum allowed tokens (default: 25000)
+ * @returns Truncated data as a json object
+ */
+export function truncateOccurrence(
+  occurrence: any,
+  maxTokens: number = 25000,
+): unknown {
+  // Convert token limit to approximate byte size for rollbar truncation
+  const maxBytes = maxTokens * CHARS_PER_TOKEN;
+
+  // Use rollbar.js truncation with our calculated max size
+  const result = truncation.truncate(occurrence, JSON.stringify, maxBytes);
+  const truncatedPayload: unknown = JSON.parse(result.value);
+  return truncatedPayload;
+}

--- a/tests/unit/tools/get-item-details.test.ts
+++ b/tests/unit/tools/get-item-details.test.ts
@@ -12,6 +12,25 @@ vi.mock('../../../src/config.js', () => ({
   ROLLBAR_ACCESS_TOKEN: 'test-token'
 }));
 
+vi.mock('../../../src/utils/truncation.js', () => ({
+  truncateOccurrence: vi.fn((occurrence, maxTokens) => {
+    // Simple mock that adds a flag if truncation happens
+    const size = JSON.stringify(occurrence).length;
+    const maxSize = maxTokens * 4; // 4 chars per token
+    if (size > maxSize) {
+      return {
+        ...occurrence,
+        _truncated: true,
+        data: {
+          ...occurrence.data,
+          body: { message: 'Truncated for testing' }
+        }
+      };
+    }
+    return occurrence;
+  })
+}));
+
 describe('get-item-details tool', () => {
   let server: McpServer;
   let toolHandler: any;
@@ -40,7 +59,8 @@ describe('get-item-details tool', () => {
       'get-item-details',
       'Get item details for a Rollbar item',
       expect.objectContaining({
-        counter: expect.any(Object)
+        counter: expect.any(Object),
+        max_tokens: expect.any(Object)
       }),
       expect.any(Function)
     );
@@ -160,15 +180,115 @@ describe('get-item-details tool', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  it('should format response as JSON with proper indentation', async () => {
+  it('should format response as valid JSON', async () => {
     makeRollbarRequestMock
       .mockResolvedValueOnce(mockSuccessfulItemResponse)
       .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
 
     const result = await toolHandler({ counter: 42 });
 
-    expect(result.content[0].text).toContain('  '); // Check for indentation
+    // Check that it's valid JSON
     const parsedText = JSON.parse(result.content[0].text);
     expect(parsedText).toBeTruthy();
+    expect(parsedText.counter).toBe(42);
+  });
+
+  describe('truncation functionality', () => {
+    it('should truncate large responses when they exceed max_tokens', async () => {
+      // Create a large occurrence response with many stack frames
+      const largeOccurrenceResponse = {
+        ...mockSuccessfulOccurrenceResponse,
+        result: {
+          ...mockSuccessfulOccurrenceResponse.result,
+          data: {
+            ...mockSuccessfulOccurrenceResponse.result.data,
+            body: {
+              trace: {
+                frames: Array(1000).fill({
+                  filename: '/very/long/path/to/some/file/that/contains/lots/of/characters/in/the/filename.js',
+                  lineno: 123,
+                  colno: 45,
+                  method: 'veryLongMethodNameThatContainsLotsOfCharacters',
+                  code: 'const x = someVeryLongVariableNameThatContainsLotsOfCharacters + anotherVeryLongVariableName;'
+                })
+              }
+            },
+            request: {
+              url: 'https://example.com/very/long/url/path',
+              body: 'x'.repeat(10000), // Very long request body
+              headers: Object.fromEntries(
+                Array(100).fill(null).map((_, i) => [`header-${i}`, 'x'.repeat(100)])
+              )
+            }
+          }
+        }
+      };
+
+      makeRollbarRequestMock
+        .mockResolvedValueOnce(mockSuccessfulItemResponse)
+        .mockResolvedValueOnce(largeOccurrenceResponse);
+
+      // Set a low token limit to force truncation
+      const result = await toolHandler({ counter: 42, max_tokens: 1000 });
+
+      const responseData = JSON.parse(result.content[0].text);
+      
+      // Response should be truncated
+      const responseText = result.content[0].text;
+      // With 1000 token limit (4000 chars), plus item data
+      // Response should be significantly smaller than original
+      const originalSize = JSON.stringify(largeOccurrenceResponse.result).length;
+      expect(responseText.length).toBeLessThan(originalSize);
+    });
+
+    it('should not truncate small responses', async () => {
+      makeRollbarRequestMock
+        .mockResolvedValueOnce(mockSuccessfulItemResponse)
+        .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
+
+      const result = await toolHandler({ counter: 42, max_tokens: 25000 });
+
+      const responseData = JSON.parse(result.content[0].text);
+      
+      // Response should contain all expected fields
+      expect(responseData.counter).toBe(42);
+      expect(responseData.occurrence).toBeDefined();
+    });
+
+    it('should use default max_tokens when not specified', async () => {
+      makeRollbarRequestMock
+        .mockResolvedValueOnce(mockSuccessfulItemResponse)
+        .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
+
+      const result = await toolHandler({ counter: 42 });
+
+      const responseData = JSON.parse(result.content[0].text);
+      expect(responseData).toBeTruthy();
+    });
+
+    it('should return item without occurrence when occurrence fetch fails', async () => {
+      makeRollbarRequestMock
+        .mockResolvedValueOnce(mockSuccessfulItemResponse)
+        .mockResolvedValueOnce(mockErrorResponse);
+
+      const result = await toolHandler({ counter: 42, max_tokens: 100 });
+
+      const responseData = JSON.parse(result.content[0].text);
+      // Should return item data without occurrence (no truncation applied to items)
+      expect(responseData).toEqual(mockSuccessfulItemResponse.result);
+      expect(responseData.occurrence).toBeUndefined();
+    });
+  });
+
+  it('should validate max_tokens parameter with Zod schema', () => {
+    const schemaCall = (server.tool as any).mock.calls[0];
+    const schema = schemaCall[2];
+    
+    expect(() => schema.max_tokens.parse(25000)).not.toThrow();
+    expect(() => schema.max_tokens.parse(1000)).not.toThrow();
+    expect(() => schema.max_tokens.parse(undefined)).not.toThrow(); // Optional
+    expect(() => schema.max_tokens.parse(3.14)).toThrow();
+    expect(() => schema.max_tokens.parse('25000')).toThrow();
+    expect(() => schema.max_tokens.parse(-1)).not.toThrow(); // Negative allowed by schema
   });
 });

--- a/tests/unit/utils/truncation.test.ts
+++ b/tests/unit/utils/truncation.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import { truncateOccurrence } from "../../../src/utils/truncation.js";
+
+// Mock the rollbar module
+vi.mock("module", () => ({
+  createRequire: () => () => ({
+    truncate: vi.fn((payload, jsonBackup, maxBytes) => {
+      // Simple mock truncation that returns data if under limit
+      const dataStr = JSON.stringify(payload);
+      if (dataStr.length <= maxBytes) {
+        return { value: dataStr };
+      }
+      // Return truncated version - simulate rollbar truncation
+      const truncated = {
+        ...payload,
+        data: {
+          ...payload.data,
+          _truncated: true,
+        },
+      };
+      return { value: JSON.stringify(truncated) };
+    }),
+  }),
+}));
+
+describe("truncation", () => {
+  describe("truncateOccurrence", () => {
+    it("should not truncate small occurrences", () => {
+      const occurrence = {
+        id: 123,
+        data: {
+          body: { message: "Small message" },
+          level: "error",
+        },
+      };
+      
+      const result = truncateOccurrence(occurrence, 10000);
+      expect(result).toEqual(occurrence);
+      expect(result.data._truncated).toBeUndefined();
+    });
+
+    it("should truncate large occurrences", () => {
+      const occurrence = {
+        id: 456,
+        data: {
+          body: {
+            trace: {
+              frames: Array(1000).fill({
+                filename: "/very/long/path/to/file.py",
+                lineno: 123,
+                method: "some_method",
+              }),
+            },
+          },
+          level: "error",
+        },
+      };
+      
+      const result = truncateOccurrence(occurrence, 100);
+      expect(result.data._truncated).toBe(true);
+    });
+
+    it("should use default max tokens when not specified", () => {
+      const occurrence = {
+        id: 789,
+        data: { body: { message: "Test" } },
+      };
+      
+      const result = truncateOccurrence(occurrence);
+      expect(result).toBeDefined();
+      expect(result.id).toBe(789);
+    });
+
+    it("should handle occurrences with complex nested structures", () => {
+      const occurrence = {
+        id: 999,
+        data: {
+          body: {
+            trace_chain: [
+              {
+                frames: Array(50).fill({ frame: "data" }),
+                exception: { class: "Error", message: "Test error" },
+              },
+              {
+                frames: Array(50).fill({ frame: "data" }),
+                exception: { class: "ValueError", message: "Another error" },
+              },
+            ],
+          },
+          request: {
+            url: "https://example.com",
+            headers: { "Content-Type": "application/json" },
+          },
+        },
+      };
+      
+      const result = truncateOccurrence(occurrence, 500);
+      expect(result).toBeDefined();
+      expect(result.id).toBe(999);
+    });
+
+    it("should preserve occurrence structure after truncation", () => {
+      const occurrence = {
+        id: 111,
+        project_id: 222,
+        timestamp: 1234567890,
+        data: {
+          body: {
+            message: "x".repeat(10000),
+          },
+          level: "warning",
+          environment: "production",
+        },
+      };
+      
+      const result = truncateOccurrence(occurrence, 50);
+      expect(result.id).toBe(111);
+      expect(result.data).toBeDefined();
+      expect(result.data._truncated).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# Description

## Problem

The `get-item-details` tool returns item data and the most recent occurrence. Occurrence payloads can be large, for example, if there is a stack trace with hundreds of frames. This makes it easy to exceed the default 25,000 token limit for tool call responses in Claude Code.

Issue: https://github.com/rollbar/rollbar-mcp-server/issues/28

## Solution

Truncate the occurrence data if it is large. We set a 20k default max, and estimate tokens by dividing string length by 4. Note, the total tool call response will be a bit larger than this since the item data is not truncated (but all fields are limited in length, so should not be an issue). You can set a higher or lower max by passing the argument `max_tokens` with your tool call to `get-item-details`.

This is the same problem faced in rollbar.js when sending payloads to the Rollbar API (except that now the limit is smaller). So we've added rollbar.js as a dependency. The truncation logic tries its best to maintain valuable data in the payload while truncating to reach a target maxBytes.

Notes:
- Added rollbar.js at 3.0.0-alpha.2 (not a newer version) because importing `truncation` directly does not (yet) work in newer versions. This is an open issue: https://github.com/rollbar/rollbar.js/pull/1286

## Screenshots

Example tool calls for an item with a very long stack trace. The first, with max_tokens 20k, expectedly succeeds. The second, which intentionally sets max_tokens to 200k (above the claude code default of 25k), expectedly fails. The third, which does not set max_tokens, relies on the default of 20k and it expectedly succeeds.

<img width="1045" height="417" alt="image" src="https://github.com/user-attachments/assets/9928ce37-23a6-4209-a3ae-aaf9132eb256" />
