### PR TITLE
Fix unexpected stdout output during startup

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,8 @@
 import dotenv from "dotenv";
 
 // Load environment variables from .env file
-dotenv.config();
+// `quiet: true` to prevent logging to stdio which disrupts some mcp clients
+dotenv.config({ quiet: true });
 
 export const ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
 export const USER_AGENT = "rollbar-mcp-server/0.0.1";


### PR DESCRIPTION
## Problem

Prior to this change, rollbar-mcp-server might output dotenv log messages during startup. This breaks strict mcp clients like PHPStorm Junie.

Issue: https://github.com/rollbar/rollbar-mcp-server/issues/39

## Solution

- Use dotenv quiet mode
- Added e2e test to detect this situation