### PR TITLE
Fix e2e test failure by pinning modelcontextprotocol/inspector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.1",
-        "@modelcontextprotocol/inspector": "^0.16.2",
+        "@modelcontextprotocol/inspector": "0.16.2",
         "@types/node": "^24.1.0",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.25.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",
-    "@modelcontextprotocol/inspector": "^0.16.2",
+    "@modelcontextprotocol/inspector": "0.16.2",
     "@types/node": "^24.1.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.25.1",

--- a/tests/e2e/test-get-item-details.sh
+++ b/tests/e2e/test-get-item-details.sh
@@ -63,10 +63,16 @@ cd "$TEMP_DIR"
 # Copy the tarball to temp dir for npx to use
 cp "$PROJECT_ROOT/$TARBALL" .
 
-echo "Running: npx --yes --no-install @modelcontextprotocol/inspector --cli -e ROLLBAR_ACCESS_TOKEN=\$ROLLBAR_E2E_READ_TOKEN npx --yes ./$TARBALL --method tools/call --tool-name get-item-details --tool-arg counter=8 --tool-arg max_tokens=100"
+INSPECTOR_BIN="$PROJECT_ROOT/node_modules/.bin/mcp-inspector"
+if [ ! -x "$INSPECTOR_BIN" ]; then
+    echo -e "${RED}✗ MCP inspector binary not found at $INSPECTOR_BIN${NC}"
+    exit 1
+fi
+
+echo "Running: $INSPECTOR_BIN --cli -e ROLLBAR_ACCESS_TOKEN=\$ROLLBAR_E2E_READ_TOKEN npx --yes ./$TARBALL --method tools/call --tool-name get-item-details --tool-arg counter=8 --tool-arg max_tokens=100"
 
 # Run the command and capture output
-npx --yes --no-install @modelcontextprotocol/inspector --cli -e ROLLBAR_ACCESS_TOKEN=$ROLLBAR_E2E_READ_TOKEN npx --yes ./$TARBALL --method tools/call --tool-name get-item-details --tool-arg counter=8 --tool-arg max_tokens=100 > test-output.json 2>&1
+"$INSPECTOR_BIN" --cli -e ROLLBAR_ACCESS_TOKEN=$ROLLBAR_E2E_READ_TOKEN npx --yes ./$TARBALL --method tools/call --tool-name get-item-details --tool-arg counter=8 --tool-arg max_tokens=100 > test-output.json 2>&1
 
 # Check the output using jq
 HAS_CONTENT=$(jq -r 'has("content")' test-output.json 2>/dev/null || echo "false")


### PR DESCRIPTION
# Problem

When running the e2e test get-item-details:

```
Running: npx -y @modelcontextprotocol/inspector --cli -e ROLLBAR_ACCESS_TOKEN=$ROLLBAR_E2E_READ_TOKEN npx -y ./rollbar-mcp-server-0.2.3.tgz --method tools/call --tool-name get-item-details --tool-arg counter=8 --tool-arg max_tokens=100
✗ E2E test failed: Tool invocation returned an error
Response:
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
{
  "content": [
```

The test (rightly) fails because of the deprecation warning being printed. That happens because the latest version of `@modelcontextprotocol/inspector` depends (indirectly) on node-domexception, which is deprecated.

# Solution

Pin `@modelcontextprotocol/inspector` to 0.16.2, via devDependencies.