### PR TITLE
Make ROLLBAR_API_BASE configurable via env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ Run your local installation from Claude Code:
 }
 ```
 
+Add `ROLLBAR_API_BASE` to the `env` map if you need to point the server at a custom Rollbar API endpoint (for example, `"ROLLBAR_API_BASE": "https://rollbar-dev.example.com/api/1"`).
+
 Run your local installation from VSCode:
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This MCP server implementes the `stdio` server type, which means your AI tool (e
 
 ### Configuration
 
-`ROLLBAR_ACCESS_TOKEN`: an access token for your Rollbar project with `read` and/or `write` scope.
+- `ROLLBAR_ACCESS_TOKEN`: an access token for your Rollbar project with `read` and/or `write` scope.
+- `ROLLBAR_API_BASE` (optional): override the Rollbar API base URL (defaults to `https://api.rollbar.com/api/1`). Use this when running against a staging or development Rollbar deployment.
 
 ### Tools
 
@@ -54,6 +55,8 @@ Configure your `.mcp.json` as follows:
   }
 }
 ```
+
+Optionally include `ROLLBAR_API_BASE` in the `env` block to target a non-production API endpoint, for example `"ROLLBAR_API_BASE": "https://rollbar-dev.example.com/api/1"`.
 
 
 ### Codex CLI

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,9 @@ import packageJson from "../package.json" with { type: "json" };
 // `quiet: true` to prevent logging to stdio which disrupts some mcp clients
 dotenv.config({ quiet: true });
 
-export const ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
+const DEFAULT_ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
+
+export const ROLLBAR_API_BASE = resolveRollbarApiBase();
 export function getUserAgent(toolName: string): string {
   return `rollbar-mcp-server/${packageJson.version} (tool: ${toolName})`;
 }
@@ -16,4 +18,31 @@ if (!ROLLBAR_ACCESS_TOKEN) {
     "Error: ROLLBAR_ACCESS_TOKEN is not set in env var or .env file",
   );
   process.exit(1);
+}
+
+function resolveRollbarApiBase(): string {
+  const envValue = process.env.ROLLBAR_API_BASE?.trim();
+  if (!envValue || envValue.length === 0) {
+    return DEFAULT_ROLLBAR_API_BASE;
+  }
+
+  const sanitizedValue = envValue.replace(/\/+$/, "");
+
+  if (sanitizedValue.length === 0) {
+    console.error("Error: ROLLBAR_API_BASE must be a non-empty URL");
+    process.exit(1);
+  }
+
+  try {
+    const parsedUrl = new URL(sanitizedValue);
+    if (!["https:", "http:"].includes(parsedUrl.protocol)) {
+      throw new Error("Invalid protocol");
+    }
+    return sanitizedValue;
+  } catch {
+    console.error(
+      `Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL. Received "${envValue}".`,
+    );
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
# Problem

We want to test rollbar-mcp-server against an arbitrary rollbar instance (i.e. a development or staging instance of the Rollbar service).

# Solution

Allow configuring the api endpoint via the ROLLBAR_API_BASE environment variable.