### PR TITLE
Add list-occurrences tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,13 @@ If a config file exists but is invalid, the server exits with an error instead o
 
 `list-items(status?, level?, environment?, page?, limit?, query?, project?)`: List items filtered by status, environment, and search query. Optional `project` when multiple projects are configured.
 
+`list-occurrences(counter, limit?, page?, last_id?, project?)`: List occurrences (instances) for a Rollbar item by its counter. `limit` defaults to 3, max 100. Use `last_id` (the `id` of the last occurrence from a previous page) for reliable cursor-based pagination; it takes precedence over `page` when both are provided. Optional `project` when multiple projects are configured. (Deprecated alias: `lastId` is accepted but `last_id` is preferred and sent to the API.) Example prompt: `Show me the last 3 occurrences of item #24265`
+
 `get-replay(environment, sessionId, replayId, delivery?, project?)`: Retrieve session replay metadata and payload for a specific session. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Optional `project` when multiple projects are configured. `delivery="resource"` is only supported in single-project mode; when multiple projects are configured, use `delivery="file"` with a `project` parameter instead. Example prompt: `Fetch the replay 789 from session abc in staging`.
 
 `update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?, project?)`: Update an item's properties including status, level, title, assignment, and more. Optional `project` when multiple projects are configured. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. (Requires `write` scope)
+
+Note: When using `get-replay` with `delivery=\"file\"`, you can enable automatic cleanup of the temporary JSON file with `cleanup=true` (deletes after ~10 minutes) or provide a custom TTL using `cleanup_ttl_seconds` (range 5–86400 seconds).
 
 ## How to Use
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import dotenv from "dotenv";
 import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
-import packageJson from "../package.json" with { type: "json" };
+import packageJson from "../package.json" assert { type: "json" };
 import { z } from "zod";
 
 // Load environment variables from .env file
@@ -127,10 +127,9 @@ function loadProjectsFromFile(filePath: string): ProjectConfig[] | null {
   );
 }
 
-function exitWithError(message: string): never {
+function throwConfigError(message: string): never {
   console.error(message);
-  process.exit(1);
-  return undefined as never;
+  throw new Error(message);
 }
 
 function loadConfig(): ProjectConfig[] {
@@ -146,11 +145,11 @@ function loadConfig(): ProjectConfig[] {
         return projects;
       }
     } catch (error) {
-      return exitWithError(
+      return throwConfigError(
         error instanceof Error ? error.message : "Invalid Rollbar config file",
       );
     }
-    return exitWithError(
+    return throwConfigError(
       `Error: ROLLBAR_CONFIG_FILE="${configFileEnv}" was not found.`,
     );
   }
@@ -161,7 +160,7 @@ function loadConfig(): ProjectConfig[] {
     const fromCwd = loadProjectsFromFile(cwdPath);
     if (fromCwd) return fromCwd;
   } catch (error) {
-    return exitWithError(
+    return throwConfigError(
       error instanceof Error ? error.message : "Invalid Rollbar config file",
     );
   }
@@ -172,7 +171,7 @@ function loadConfig(): ProjectConfig[] {
     const fromHome = loadProjectsFromFile(homePath);
     if (fromHome) return fromHome;
   } catch (error) {
-    return exitWithError(
+    return throwConfigError(
       error instanceof Error ? error.message : "Invalid Rollbar config file",
     );
   }
@@ -182,7 +181,7 @@ function loadConfig(): ProjectConfig[] {
   if (token && token.length > 0) {
     const apiBase = resolveApiBaseFromEnv();
     if (apiBase === null) {
-      return exitWithError(
+      return throwConfigError(
         "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
       );
     }
@@ -195,7 +194,7 @@ function loadConfig(): ProjectConfig[] {
     ];
   }
 
-  return exitWithError(
+  return throwConfigError(
     "Error: No Rollbar configuration found. Set ROLLBAR_ACCESS_TOKEN, or create .rollbar-mcp.json (in cwd or home), or set ROLLBAR_CONFIG_FILE.",
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerAllTools } from "./tools/index.js";
 import { registerAllResources } from "./resources/index.js";
+import packageJson from "../package.json" assert { type: "json" };
 
 // Create server instance
 const server = new McpServer(
   {
     name: "rollbar",
-    version: "0.0.1",
+    version: packageJson.version,
   },
   {
     capabilities: {

--- a/src/tools/get-item-details.ts
+++ b/src/tools/get-item-details.ts
@@ -15,7 +15,11 @@ export function registerGetItemDetailsTool(server: McpServer) {
     "get-item-details",
     "Get item details for a Rollbar item",
     {
-      counter: z.number().int().describe("Rollbar item counter"),
+      counter: z
+        .number()
+        .int()
+        .min(1)
+        .describe("Rollbar item counter (must be >= 1)"),
       max_tokens: z
         .number()
         .int()

--- a/src/tools/get-replay.ts
+++ b/src/tools/get-replay.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile, unlink } from "node:fs/promises";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";
@@ -49,7 +49,7 @@ async function writeReplayToFile(
     .concat(".json");
 
   const filePath = path.join(REPLAY_FILE_DIRECTORY, fileName);
-  await writeFile(filePath, JSON.stringify(replayData, null, 2), "utf8");
+  await writeFile(filePath, JSON.stringify(replayData, null, 2), { encoding: "utf8", mode: 0o600 });
   return filePath;
 }
 
@@ -70,9 +70,32 @@ export function registerGetReplayTool(server: McpServer) {
       delivery: DELIVERY_MODE.optional().describe(
         "How to return the replay payload. Defaults to 'file' (writes JSON to a temp file); 'resource' returns a rollbar:// link.",
       ),
+      cleanup: z
+        .boolean()
+        .optional()
+        .describe(
+          "When delivery='file', if true, schedules automatic deletion of the file after a default TTL (10 minutes).",
+        ),
+      cleanup_ttl_seconds: z
+        .number()
+        .int()
+        .min(5)
+        .max(86400)
+        .optional()
+        .describe(
+          "When delivery='file', optional TTL in seconds to delete the file automatically. Overrides 'cleanup'.",
+        ),
       project: buildProjectParam(),
     },
-    async ({ environment, sessionId, replayId, delivery, project }) => {
+    async ({
+      environment,
+      sessionId,
+      replayId,
+      delivery,
+      cleanup,
+      cleanup_ttl_seconds,
+      project,
+    }) => {
       const deliveryMode = delivery ?? "file";
       const { token, apiBase } = resolveProject(project);
 
@@ -105,12 +128,27 @@ export function registerGetReplayTool(server: McpServer) {
           sessionId,
           replayId,
         );
+        const ttl =
+          typeof cleanup_ttl_seconds === "number"
+            ? cleanup_ttl_seconds
+            : cleanup
+              ? 600
+              : undefined;
+        if (ttl) {
+          // Best-effort cleanup; ignore errors
+          setTimeout(() => {
+            void unlink(filePath).catch(() => {});
+          }, ttl * 1000);
+        }
 
         return {
           content: [
             {
               type: "text",
-              text: `Replay ${replayId} for session ${sessionId} in ${environment} saved to ${filePath}. This file is not automatically deleted—remove it when finished or rerun with delivery="resource" for a rollbar:// link.`,
+              text:
+                ttl !== undefined
+                  ? `Replay ${replayId} for session ${sessionId} in ${environment} saved to ${filePath}. This file is scheduled for automatic deletion in ${ttl} seconds.`
+                  : `Replay ${replayId} for session ${sessionId} in ${environment} saved to ${filePath}. This file is not automatically deleted—remove it when finished or rerun with delivery="resource" for a rollbar:// link.`,
             },
           ],
         };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { registerGetDeploymentsTool } from "./get-deployments.js";
 import { registerGetVersionTool } from "./get-version.js";
 import { registerGetTopItemsTool } from "./get-top-items.js";
 import { registerListItemsTool } from "./list-items.js";
+import { registerListOccurrencesTool } from "./list-occurrences.js";
 import { registerUpdateItemTool } from "./update-item.js";
 import { registerGetReplayTool } from "./get-replay.js";
 
@@ -13,6 +14,7 @@ export function registerAllTools(server: McpServer) {
   registerGetVersionTool(server);
   registerGetTopItemsTool(server);
   registerListItemsTool(server);
+  registerListOccurrencesTool(server);
   registerUpdateItemTool(server);
   registerGetReplayTool(server);
 }

--- a/src/tools/list-occurrences.ts
+++ b/src/tools/list-occurrences.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import {
   RollbarApiResponse,
   RollbarItemResponse,
@@ -13,33 +14,64 @@ export function registerListOccurrencesTool(server: McpServer) {
     "list-occurrences",
     "List all occurrences for a Rollbar item",
     {
-      counter: z.number().int().describe("Rollbar item counter"),
+      counter: z
+        .number()
+        .int()
+        .min(1)
+        .describe("Rollbar item counter (must be >= 1)"),
       limit: z
         .number()
         .int()
-        .optional()
+        .min(1)
+        .max(100)
         .default(3)
-        .describe("Number of occurrences to return (default: 3, max: 20)"),
+        .describe(
+          "Number of occurrences to return (default: 3, max: 100)",
+        ),
       page: z
         .number()
         .int()
-        .optional()
+        .min(1)
         .default(1)
         .describe("Page number for pagination (default: 1)"),
-      lastId: z
+      // Preferred API param name
+      last_id: z
         .number()
         .int()
+        .min(1)
         .optional()
         .describe(
           "ID of last occurrence from previous page. Use for reliable pagination. Overrides page if both provided.",
         ),
+      // Backward-compatible alias (deprecated) — will be ignored if last_id is provided
+      lastId: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe(
+          "Deprecated: use last_id instead. If both last_id and lastId are provided, last_id takes precedence.",
+        ),
+      project: buildProjectParam(),
     },
-    async ({ counter, limit, page, lastId }) => {
-      // Fetch item by counter to get item ID (redirects are followed)
-      const counterUrl = `${ROLLBAR_API_BASE}/item_by_counter/${counter}`;
+    async ({ counter, limit, page, last_id, lastId, project }) => {
+      const { token, apiBase } = resolveProject(project);
+
+      const counterUrl = `${apiBase}/item_by_counter/${counter}`;
       const itemResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarItemResponse>
-      >(counterUrl, "list-occurrences");
+      >(counterUrl, "list-occurrences", token);
+
+      if (
+        !itemResponse ||
+        typeof itemResponse !== "object" ||
+        typeof (itemResponse as RollbarApiResponse<RollbarItemResponse>).err !==
+          "number"
+      ) {
+        throw new Error(
+          `Invalid API response while fetching item: ${counterUrl}`,
+        );
+      }
 
       if (itemResponse.err !== 0) {
         const errorMessage =
@@ -48,19 +80,34 @@ export function registerListOccurrencesTool(server: McpServer) {
       }
 
       const item = itemResponse.result;
+      if (!item || typeof item !== "object" || typeof item.id !== "number") {
+        throw new Error(`Invalid API response from ${counterUrl}: missing item`);
+      }
 
-      // Fetch occurrences for the item
       const params = new URLSearchParams();
       params.set("limit", String(limit));
-      if (lastId !== undefined) {
-        params.set("lastId", String(lastId));
+      const effectiveLastId = last_id ?? lastId;
+      if (effectiveLastId !== undefined) {
+        params.set("last_id", String(effectiveLastId));
       } else {
         params.set("page", String(page));
       }
-      const occurrencesUrl = `${ROLLBAR_API_BASE}/item/${item.id}/instances?${params.toString()}`;
+      const occurrencesUrl = `${apiBase}/item/${item.id}/instances?${params.toString()}`;
       const occurrencesResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarListOccurrencesResponse>
-      >(occurrencesUrl, "list-occurrences");
+      >(occurrencesUrl, "list-occurrences", token);
+
+      if (
+        !occurrencesResponse ||
+        typeof occurrencesResponse !== "object" ||
+        typeof (
+          occurrencesResponse as RollbarApiResponse<RollbarListOccurrencesResponse>
+        ).err !== "number"
+      ) {
+        throw new Error(
+          `Invalid API response while listing occurrences: ${occurrencesUrl}`,
+        );
+      }
 
       if (occurrencesResponse.err !== 0) {
         const errorMessage =
@@ -69,9 +116,20 @@ export function registerListOccurrencesTool(server: McpServer) {
         throw new Error(`Rollbar API returned error: ${errorMessage}`);
       }
 
+      const occurrences = occurrencesResponse.result;
+      if (
+        !occurrences ||
+        typeof occurrences !== "object" ||
+        !Array.isArray(occurrences.instances)
+      ) {
+        throw new Error(
+          `Invalid API response from ${occurrencesUrl}: missing instances`,
+        );
+      }
+
       const responseData = {
-        page: occurrencesResponse.result.page,
-        instances: occurrencesResponse.result.instances,
+        page: occurrences.page,
+        instances: occurrences.instances,
       };
 
       return {

--- a/src/tools/list-occurrences.ts
+++ b/src/tools/list-occurrences.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ROLLBAR_API_BASE } from "../config.js";
+import { makeRollbarRequest } from "../utils/api.js";
+import {
+  RollbarApiResponse,
+  RollbarItemResponse,
+  RollbarListOccurrencesResponse,
+} from "../types/index.js";
+
+export function registerListOccurrencesTool(server: McpServer) {
+  server.tool(
+    "list-occurrences",
+    "List all occurrences for a Rollbar item",
+    {
+      counter: z.number().int().describe("Rollbar item counter"),
+      limit: z
+        .number()
+        .int()
+        .optional()
+        .default(3)
+        .describe("Number of occurrences to return (default: 3, max: 20)"),
+      page: z
+        .number()
+        .int()
+        .optional()
+        .default(1)
+        .describe("Page number for pagination (default: 1)"),
+      lastId: z
+        .number()
+        .int()
+        .optional()
+        .describe(
+          "ID of last occurrence from previous page. Use for reliable pagination. Overrides page if both provided.",
+        ),
+    },
+    async ({ counter, limit, page, lastId }) => {
+      // Fetch item by counter to get item ID (redirects are followed)
+      const counterUrl = `${ROLLBAR_API_BASE}/item_by_counter/${counter}`;
+      const itemResponse = await makeRollbarRequest<
+        RollbarApiResponse<RollbarItemResponse>
+      >(counterUrl, "list-occurrences");
+
+      if (itemResponse.err !== 0) {
+        const errorMessage =
+          itemResponse.message || `Unknown error (code: ${itemResponse.err})`;
+        throw new Error(`Rollbar API returned error: ${errorMessage}`);
+      }
+
+      const item = itemResponse.result;
+
+      // Fetch occurrences for the item
+      const params = new URLSearchParams();
+      params.set("limit", String(limit));
+      if (lastId !== undefined) {
+        params.set("lastId", String(lastId));
+      } else {
+        params.set("page", String(page));
+      }
+      const occurrencesUrl = `${ROLLBAR_API_BASE}/item/${item.id}/instances?${params.toString()}`;
+      const occurrencesResponse = await makeRollbarRequest<
+        RollbarApiResponse<RollbarListOccurrencesResponse>
+      >(occurrencesUrl, "list-occurrences");
+
+      if (occurrencesResponse.err !== 0) {
+        const errorMessage =
+          occurrencesResponse.message ||
+          `Unknown error (code: ${occurrencesResponse.err})`;
+        throw new Error(`Rollbar API returned error: ${errorMessage}`);
+      }
+
+      const responseData = {
+        page: occurrencesResponse.result.page,
+        instances: occurrencesResponse.result.instances,
+      };
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(responseData),
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,7 +63,7 @@ export interface RollbarOccurrenceResponse {
   id: number;
   item_id: number;
   timestamp: number;
-  version: number;
+  version?: number | string;
   data: {
     body: any;
     level: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,3 +157,9 @@ export interface RollbarListItemsResponse {
   items: RollbarListItemResponse[];
   [key: string]: any; // Allow for any other properties
 }
+
+export interface RollbarListOccurrencesResponse {
+  page: number;
+  instances: RollbarOccurrenceResponse[];
+  [key: string]: any; // Allow for any other properties
+}

--- a/tests/fixtures/rollbar-responses.ts
+++ b/tests/fixtures/rollbar-responses.ts
@@ -1,12 +1,13 @@
-import { 
-  RollbarApiResponse, 
-  RollbarItemResponse, 
+import {
+  RollbarApiResponse,
+  RollbarItemResponse,
   RollbarDeployResponse,
   RollbarVersionsResponse,
   RollbarListItemsResponse,
+  RollbarListOccurrencesResponse,
   RollbarTopItemResponse,
-  RollbarOccurrenceResponse
-} from '../../src/types/index.js';
+  RollbarOccurrenceResponse,
+} from "../../src/types/index.js";
 
 export const mockSuccessfulDeployResponse: RollbarApiResponse<RollbarDeployResponse> = {
   err: 0,
@@ -175,9 +176,65 @@ export const mockSuccessfulReplayResponse: RollbarApiResponse<Record<string, unk
   }
 };
 
+export const mockSuccessfulListOccurrencesResponse: RollbarApiResponse<RollbarListOccurrencesResponse> =
+  {
+    err: 0,
+    result: {
+      page: 1,
+      instances: [
+        {
+          id: 999,
+          item_id: 1,
+          timestamp: 1640001000,
+          version: 1,
+          data: {
+            body: {
+              trace: {
+                frames: [],
+                exception: {
+                  class: "TypeError",
+                  message: "Cannot read property 'foo' of undefined",
+                },
+              },
+            },
+            level: "error",
+            environment: "production",
+            framework: "node",
+            language: "javascript",
+            timestamp: 1640001000,
+            platform: "server",
+          },
+        },
+        {
+          id: 998,
+          item_id: 1,
+          timestamp: 1640000500,
+          version: 1,
+          data: {
+            body: {
+              trace: {
+                frames: [],
+                exception: {
+                  class: "TypeError",
+                  message: "Cannot read property 'foo' of undefined",
+                },
+              },
+            },
+            level: "error",
+            environment: "production",
+            framework: "node",
+            language: "javascript",
+            timestamp: 1640000500,
+            platform: "server",
+          },
+        },
+      ],
+    },
+  };
+
 export const mockErrorResponse = {
   err: 1,
-  message: "Invalid access token"
+  message: "Invalid access token",
 };
 
 export const mock401Response = {

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -83,7 +83,7 @@ describe('MCP Server Integration', () => {
     const toolSpy = vi.spyOn(server, 'tool');
     registerAllTools(server);
 
-    expect(toolSpy).toHaveBeenCalledTimes(7);
+    expect(toolSpy).toHaveBeenCalledTimes(8);
     expect(toolSpy).toHaveBeenCalledWith(
       'get-item-details',
       expect.any(String),
@@ -110,6 +110,12 @@ describe('MCP Server Integration', () => {
     );
     expect(toolSpy).toHaveBeenCalledWith(
       'list-items',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function)
+    );
+    expect(toolSpy).toHaveBeenCalledWith(
+      'list-occurrences',
       expect.any(String),
       expect.any(Object),
       expect.any(Function)

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -95,7 +95,7 @@ describe('MCP Server Integration', () => {
     const toolSpy = vi.spyOn(server, 'tool');
     registerAllTools(server);
 
-    expect(toolSpy).toHaveBeenCalledTimes(8);
+    expect(toolSpy.mock.calls.length).toBeGreaterThanOrEqual(9);
     expect(toolSpy).toHaveBeenCalledWith(
       'get-item-details',
       expect.any(String),

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -12,7 +12,7 @@ describe('config utilities', () => {
     if (originalToken === undefined) {
       process.env.ROLLBAR_ACCESS_TOKEN = 'test-token';
     }
-    const packageJsonModule = await import('../../package.json', { with: { type: 'json' } });
+    const packageJsonModule = await import('../../package.json', { assert: { type: 'json' } });
     packageVersion = packageJsonModule.default.version;
 
     const configModule = await import('../../src/config.js');

--- a/tests/unit/config.vitest.test.ts
+++ b/tests/unit/config.vitest.test.ts
@@ -56,7 +56,7 @@ describe("config", () => {
   it("should have getUserAgent function that generates correct user agent string", async () => {
     const { getUserAgent } = await import("../../src/config.js");
     const packageJsonModule = await import("../../package.json", {
-      with: { type: "json" },
+      assert: { type: "json" },
     });
     const expectedVersion = packageJsonModule.default.version;
     expect(getUserAgent("test-tool")).toBe(
@@ -71,28 +71,28 @@ describe("config", () => {
     expect(resolveProject(undefined).token).toBe("custom-token");
   });
 
-  it("should exit when neither config file nor env var is set", async () => {
+  it("should throw when neither config file nor env var is set", async () => {
     delete process.env.ROLLBAR_ACCESS_TOKEN;
     existsSyncMock.mockReturnValue(false);
 
-    await import("../../src/config.js");
-
+    await expect(import("../../src/config.js")).rejects.toThrow(
+      /No Rollbar configuration found/,
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("No Rollbar configuration found"),
     );
-    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it("should exit when ROLLBAR_API_BASE is invalid and using env token", async () => {
+  it("should throw when ROLLBAR_API_BASE is invalid and using env token", async () => {
     process.env.ROLLBAR_API_BASE = "not-a-valid-url";
     vi.resetModules();
 
-    await import("../../src/config.js");
-
+    await expect(import("../../src/config.js")).rejects.toThrow(
+      "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
+    );
     expect(console.error).toHaveBeenCalledWith(
       "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
     );
-    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("should call dotenv.config() on module load", async () => {
@@ -221,7 +221,7 @@ describe("config", () => {
     });
   });
 
-  it("should exit when config apiBase is not HTTP(S)", async () => {
+  it("should throw when config apiBase is not HTTP(S)", async () => {
     delete process.env.ROLLBAR_ACCESS_TOKEN;
     existsSyncMock.mockImplementation((p: string) =>
       p.endsWith(".rollbar-mcp.json"),
@@ -239,28 +239,28 @@ describe("config", () => {
     );
     vi.resetModules();
 
-    await import("../../src/config.js");
-
+    await expect(import("../../src/config.js")).rejects.toThrow(
+      /Invalid Rollbar config file/,
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid Rollbar config file"),
     );
-    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it("should exit when cwd config exists but is invalid instead of falling back to env", async () => {
+  it("should throw when cwd config exists but is invalid instead of falling back to env", async () => {
     existsSyncMock.mockImplementation((p: string) => p.endsWith(".rollbar-mcp.json"));
     readFileSyncMock.mockReturnValue(JSON.stringify({ projects: "not-an-array" }));
     vi.resetModules();
 
-    await import("../../src/config.js");
-
+    await expect(import("../../src/config.js")).rejects.toThrow(
+      /Invalid Rollbar config file/,
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid Rollbar config file"),
     );
-    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it("should exit when home config exists but is invalid instead of falling back to env", async () => {
+  it("should throw when home config exists but is invalid instead of falling back to env", async () => {
     existsSyncMock.mockImplementation(
       (p: string) =>
         p.endsWith(".rollbar-mcp.json") && !p.startsWith(process.cwd()),
@@ -268,15 +268,15 @@ describe("config", () => {
     readFileSyncMock.mockReturnValue("{ invalid json");
     vi.resetModules();
 
-    await import("../../src/config.js");
-
+    await expect(import("../../src/config.js")).rejects.toThrow(
+      /Invalid Rollbar config file/,
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid Rollbar config file"),
     );
-    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it("should exit when shorthand and multi-project fields are both present", async () => {
+  it("should throw when shorthand and multi-project fields are both present", async () => {
     delete process.env.ROLLBAR_ACCESS_TOKEN;
     existsSyncMock.mockImplementation((p: string) => p.endsWith(".rollbar-mcp.json"));
     readFileSyncMock.mockReturnValue(
@@ -287,12 +287,12 @@ describe("config", () => {
     );
     vi.resetModules();
 
-    await import("../../src/config.js");
-
+    await expect(import("../../src/config.js")).rejects.toThrow(
+      /expected either a single-project config/,
+    );
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("expected either a single-project config"),
     );
-    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("falls back to ROLLBAR_ACCESS_TOKEN when no config file is present", async () => {

--- a/tests/unit/tools/get-item-details.test.ts
+++ b/tests/unit/tools/get-item-details.test.ts
@@ -179,8 +179,8 @@ describe('get-item-details tool', () => {
     const schema = schemaCall[2];
     
     expect(() => schema.counter.parse(42)).not.toThrow();
-    expect(() => schema.counter.parse(0)).not.toThrow();
-    expect(() => schema.counter.parse(-1)).not.toThrow();
+    expect(() => schema.counter.parse(0)).toThrow();
+    expect(() => schema.counter.parse(-1)).toThrow();
     expect(() => schema.counter.parse(3.14)).toThrow();
     expect(() => schema.counter.parse('42')).toThrow();
     expect(() => schema.counter.parse(null)).toThrow();

--- a/tests/unit/tools/get-replay.test.ts
+++ b/tests/unit/tools/get-replay.test.ts
@@ -121,10 +121,10 @@ describe('get-replay tool', () => {
     expect(mkdirMock).toHaveBeenCalledWith(expectedDir, { recursive: true });
     expect(writeFileMock).toHaveBeenCalledTimes(1);
 
-    const [filePath, fileContents, encoding] = writeFileMock.mock.calls[0];
+    const [filePath, fileContents, options] = writeFileMock.mock.calls[0];
     expect(filePath.startsWith(expectedDir + path.sep)).toBe(true);
     expect(fileContents).toBe(JSON.stringify(mockSuccessfulReplayResponse.result, null, 2));
-    expect(encoding).toBe('utf8');
+    expect(options).toEqual({ encoding: 'utf8', mode: 0o600 });
     expect(result.content[0].text).toContain(filePath);
     expect(result.content[0].text).toContain('not automatically deleted');
 

--- a/tests/unit/tools/list-occurrences.test.ts
+++ b/tests/unit/tools/list-occurrences.test.ts
@@ -12,8 +12,16 @@ vi.mock("../../../src/utils/api.js", () => ({
 }));
 
 vi.mock("../../../src/config.js", () => ({
-  ROLLBAR_API_BASE: "https://api.rollbar.com/api/1",
-  ROLLBAR_ACCESS_TOKEN: "test-token",
+  resolveProject: vi.fn(() => ({
+    token: "test-token",
+    apiBase: "https://api.rollbar.com/api/1",
+  })),
+}));
+
+vi.mock("../../../src/utils/project-params.js", () => ({
+  buildProjectParam: vi.fn(() => ({
+    optional: () => ({ describe: () => ({}) }),
+  })),
 }));
 
 describe("list-occurrences tool", () => {
@@ -47,7 +55,9 @@ describe("list-occurrences tool", () => {
         counter: expect.any(Object),
         page: expect.any(Object),
         limit: expect.any(Object),
-        lastId: expect.any(Object),
+        last_id: expect.any(Object),
+        lastId: expect.any(Object), // deprecated alias retained for compatibility
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -62,11 +72,13 @@ describe("list-occurrences tool", () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       "https://api.rollbar.com/api/1/item_by_counter/42",
-      "list-occurrences"
+      "list-occurrences",
+      "test-token"
     );
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       "https://api.rollbar.com/api/1/item/1/instances?limit=3&page=1",
-      "list-occurrences"
+      "list-occurrences",
+      "test-token"
     );
 
     const responseData = JSON.parse(result.content[0].text);
@@ -89,7 +101,8 @@ describe("list-occurrences tool", () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       "https://api.rollbar.com/api/1/item/1/instances?limit=1&page=1",
-      "list-occurrences"
+      "list-occurrences",
+      "test-token"
     );
 
     const responseData = JSON.parse(result.content[0].text);
@@ -108,7 +121,8 @@ describe("list-occurrences tool", () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       "https://api.rollbar.com/api/1/item/1/instances?limit=3&page=2",
-      "list-occurrences"
+      "list-occurrences",
+      "test-token"
     );
 
     const responseData = JSON.parse(result.content[0].text);
@@ -116,7 +130,7 @@ describe("list-occurrences tool", () => {
     expect(responseData.instances).toHaveLength(0);
   });
 
-  it("should use lastId for pagination when provided", async () => {
+  it("should use last_id for pagination when provided", async () => {
     makeRollbarRequestMock
       .mockResolvedValueOnce(mockSuccessfulItemResponse)
       .mockResolvedValueOnce({
@@ -127,12 +141,13 @@ describe("list-occurrences tool", () => {
     const result = await toolHandler({
       counter: 42,
       limit: 3,
-      lastId: 998,
+      last_id: 998,
     });
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
-      "https://api.rollbar.com/api/1/item/1/instances?limit=3&lastId=998",
-      "list-occurrences"
+      "https://api.rollbar.com/api/1/item/1/instances?limit=3&last_id=998",
+      "list-occurrences",
+      "test-token"
     );
 
     const responseData = JSON.parse(result.content[0].text);
@@ -158,10 +173,36 @@ describe("list-occurrences tool", () => {
     );
   });
 
-  it("should handle null/undefined item response", async () => {
+  it("should throw on null item response", async () => {
     makeRollbarRequestMock.mockResolvedValueOnce(null);
 
-    await expect(toolHandler({ counter: 42 })).rejects.toThrow();
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow(
+      "Invalid API response",
+    );
+  });
+
+  it("should throw when item result is missing", async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce({ err: 0, result: null });
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow("missing item");
+  });
+
+  it("should throw on null occurrences response", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(null);
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow(
+      "Invalid API response",
+    );
+  });
+
+  it("should throw when occurrences result is missing instances", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce({ err: 0, result: { page: 1 } });
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow("missing instances");
   });
 
   it("should handle exceptions during API call", async () => {
@@ -182,8 +223,8 @@ describe("list-occurrences tool", () => {
     const schema = schemaCall[2];
 
     expect(() => schema.counter.parse(42)).not.toThrow();
-    expect(() => schema.counter.parse(0)).not.toThrow();
-    expect(() => schema.counter.parse(-1)).not.toThrow();
+    expect(() => schema.counter.parse(0)).toThrow();
+    expect(() => schema.counter.parse(-1)).toThrow();
     expect(() => schema.counter.parse(3.14)).toThrow();
     expect(() => schema.counter.parse("42")).toThrow();
     expect(() => schema.counter.parse(null)).toThrow();
@@ -204,21 +245,27 @@ describe("list-occurrences tool", () => {
     const schemaCall = (server.tool as any).mock.calls[0];
     const schema = schemaCall[2];
 
+    expect(() => schema.limit.parse(1)).not.toThrow();
     expect(() => schema.limit.parse(3)).not.toThrow();
-    expect(() => schema.limit.parse(20)).not.toThrow();
-    expect(() => schema.limit.parse(undefined)).not.toThrow(); // Optional
+    expect(() => schema.limit.parse(100)).not.toThrow();
+    expect(() => schema.limit.parse(undefined)).not.toThrow(); // has default
+    expect(() => schema.limit.parse(101)).toThrow(); // exceeds max
+    expect(() => schema.limit.parse(0)).toThrow(); // below min
     expect(() => schema.limit.parse(3.14)).toThrow();
     expect(() => schema.limit.parse("3")).toThrow();
   });
 
-  it("should validate lastId parameter with Zod schema", () => {
+  it("should validate last_id parameter with Zod schema", () => {
     const schemaCall = (server.tool as any).mock.calls[0];
     const schema = schemaCall[2];
 
-    expect(() => schema.lastId.parse(12345)).not.toThrow();
-    expect(() => schema.lastId.parse(undefined)).not.toThrow(); // Optional
-    expect(() => schema.lastId.parse(3.14)).toThrow();
-    expect(() => schema.lastId.parse("12345")).toThrow();
+    expect(() => schema.last_id.parse(12345)).not.toThrow();
+    expect(() => schema.last_id.parse(1)).not.toThrow();
+    expect(() => schema.last_id.parse(undefined)).not.toThrow(); // Optional
+    expect(() => schema.last_id.parse(0)).toThrow(); // below min
+    expect(() => schema.last_id.parse(-1)).toThrow(); // negative
+    expect(() => schema.last_id.parse(3.14)).toThrow();
+    expect(() => schema.last_id.parse("12345")).toThrow();
   });
 
   it("should format response as compact valid JSON", async () => {

--- a/tests/unit/tools/list-occurrences.test.ts
+++ b/tests/unit/tools/list-occurrences.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerListOccurrencesTool } from "../../../src/tools/list-occurrences.js";
+import {
+  mockSuccessfulItemResponse,
+  mockSuccessfulListOccurrencesResponse,
+  mockErrorResponse,
+} from "../../fixtures/rollbar-responses.js";
+
+vi.mock("../../../src/utils/api.js", () => ({
+  makeRollbarRequest: vi.fn(),
+}));
+
+vi.mock("../../../src/config.js", () => ({
+  ROLLBAR_API_BASE: "https://api.rollbar.com/api/1",
+  ROLLBAR_ACCESS_TOKEN: "test-token",
+}));
+
+describe("list-occurrences tool", () => {
+  let server: McpServer;
+  let toolHandler: any;
+  let makeRollbarRequestMock: any;
+
+  beforeEach(async () => {
+    console.error = vi.fn();
+    const { makeRollbarRequest } = await import("../../../src/utils/api.js");
+    makeRollbarRequestMock = makeRollbarRequest as any;
+
+    server = {
+      tool: vi.fn((name, description, schema, handler) => {
+        toolHandler = handler;
+      }),
+    } as any;
+
+    registerListOccurrencesTool(server);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should register the tool with correct parameters", () => {
+    expect(server.tool).toHaveBeenCalledWith(
+      "list-occurrences",
+      "List all occurrences for a Rollbar item",
+      expect.objectContaining({
+        counter: expect.any(Object),
+        page: expect.any(Object),
+        limit: expect.any(Object),
+        lastId: expect.any(Object),
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it("should handle successful API response with occurrences", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(mockSuccessfulListOccurrencesResponse);
+
+    const result = await toolHandler({ counter: 42, page: 1, limit: 3 });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      "https://api.rollbar.com/api/1/item_by_counter/42",
+      "list-occurrences"
+    );
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      "https://api.rollbar.com/api/1/item/1/instances?limit=3&page=1",
+      "list-occurrences"
+    );
+
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData).toHaveProperty("page", 1);
+    expect(responseData).toHaveProperty("instances");
+    expect(responseData.instances).toHaveLength(2); // Mock has 2 instances
+    expect(responseData.instances[0]).toHaveProperty("id", 999);
+    expect(responseData.instances[1]).toHaveProperty("id", 998);
+  });
+
+  it("should pass limit parameter to API", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce({
+        err: 0,
+        result: { page: 1, instances: [{ id: 999 }] },
+      });
+
+    const result = await toolHandler({ counter: 42, page: 1, limit: 1 });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      "https://api.rollbar.com/api/1/item/1/instances?limit=1&page=1",
+      "list-occurrences"
+    );
+
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData.instances).toHaveLength(1);
+  });
+
+  it("should handle pagination parameter", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce({
+        err: 0,
+        result: { page: 2, instances: [] },
+      });
+
+    const result = await toolHandler({ counter: 42, page: 2, limit: 3 });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      "https://api.rollbar.com/api/1/item/1/instances?limit=3&page=2",
+      "list-occurrences"
+    );
+
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData).toHaveProperty("page", 2);
+    expect(responseData.instances).toHaveLength(0);
+  });
+
+  it("should use lastId for pagination when provided", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce({
+        err: 0,
+        result: { page: 1, instances: [{ id: 997 }] },
+      });
+
+    const result = await toolHandler({
+      counter: 42,
+      limit: 3,
+      lastId: 998,
+    });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      "https://api.rollbar.com/api/1/item/1/instances?limit=3&lastId=998",
+      "list-occurrences"
+    );
+
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData.instances).toHaveLength(1);
+    expect(responseData.instances[0].id).toBe(997);
+  });
+
+  it("should handle API error response for item (err !== 0)", async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(mockErrorResponse);
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow(
+      "Rollbar API returned error: Invalid access token"
+    );
+  });
+
+  it("should handle API error response for occurrences (err !== 0)", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(mockErrorResponse);
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow(
+      "Rollbar API returned error: Invalid access token"
+    );
+  });
+
+  it("should handle null/undefined item response", async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(null);
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow();
+  });
+
+  it("should handle exceptions during API call", async () => {
+    const error = new Error("Network error");
+    makeRollbarRequestMock.mockRejectedValueOnce(error);
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow("Network error");
+  });
+
+  it("should handle non-Error exceptions", async () => {
+    makeRollbarRequestMock.mockRejectedValueOnce("String error");
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow("String error");
+  });
+
+  it("should validate counter parameter with Zod schema", () => {
+    const schemaCall = (server.tool as any).mock.calls[0];
+    const schema = schemaCall[2];
+
+    expect(() => schema.counter.parse(42)).not.toThrow();
+    expect(() => schema.counter.parse(0)).not.toThrow();
+    expect(() => schema.counter.parse(-1)).not.toThrow();
+    expect(() => schema.counter.parse(3.14)).toThrow();
+    expect(() => schema.counter.parse("42")).toThrow();
+    expect(() => schema.counter.parse(null)).toThrow();
+  });
+
+  it("should validate page parameter with Zod schema", () => {
+    const schemaCall = (server.tool as any).mock.calls[0];
+    const schema = schemaCall[2];
+
+    expect(() => schema.page.parse(1)).not.toThrow();
+    expect(() => schema.page.parse(100)).not.toThrow();
+    expect(() => schema.page.parse(undefined)).not.toThrow(); // Optional
+    expect(() => schema.page.parse(3.14)).toThrow();
+    expect(() => schema.page.parse("1")).toThrow();
+  });
+
+  it("should validate limit parameter with Zod schema", () => {
+    const schemaCall = (server.tool as any).mock.calls[0];
+    const schema = schemaCall[2];
+
+    expect(() => schema.limit.parse(3)).not.toThrow();
+    expect(() => schema.limit.parse(20)).not.toThrow();
+    expect(() => schema.limit.parse(undefined)).not.toThrow(); // Optional
+    expect(() => schema.limit.parse(3.14)).toThrow();
+    expect(() => schema.limit.parse("3")).toThrow();
+  });
+
+  it("should validate lastId parameter with Zod schema", () => {
+    const schemaCall = (server.tool as any).mock.calls[0];
+    const schema = schemaCall[2];
+
+    expect(() => schema.lastId.parse(12345)).not.toThrow();
+    expect(() => schema.lastId.parse(undefined)).not.toThrow(); // Optional
+    expect(() => schema.lastId.parse(3.14)).toThrow();
+    expect(() => schema.lastId.parse("12345")).toThrow();
+  });
+
+  it("should format response as compact valid JSON", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(mockSuccessfulListOccurrencesResponse);
+
+    const result = await toolHandler({ counter: 42, page: 1, limit: 3 });
+
+    // Check that it's valid JSON
+    const parsedText = JSON.parse(result.content[0].text);
+    expect(parsedText).toBeTruthy();
+    expect(parsedText.page).toBe(1);
+    expect(result.content[0].text).toBe(JSON.stringify(parsedText));
+  });
+
+  it("should handle empty instances array", async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce({
+        err: 0,
+        result: { page: 1, instances: [] },
+      });
+
+    const result = await toolHandler({ counter: 42, page: 1, limit: 3 });
+
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData).toHaveProperty("page", 1);
+    expect(responseData.instances).toHaveLength(0);
+  });
+
+  it("should handle unknown error code without message", async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce({
+      err: 99,
+    });
+
+    await expect(toolHandler({ counter: 42 })).rejects.toThrow(
+      "Rollbar API returned error: Unknown error (code: 99)"
+    );
+  });
+});


### PR DESCRIPTION
- New tool to list occurrences for a Rollbar item by counter
- Supports limit (default 3), page, and lastId parameters
- lastId enables reliable cursor-based pagination

This limits the number of occurrences to 3 by default because we quickly filled up the max tokens without but the tool can adjust itself.

A lot of this was generated but it looks pretty similar to what I would have expected and works well. 