### PR TITLE
Add multi-project support via config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.rollbar-mcp.json
 
 node_modules/
 build/

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Multiple projects:
   "projects": [
     { "name": "backend",  "token": "tok_abc123" },
     { "name": "frontend", "token": "tok_xyz789" },
-    { "name": "staging",  "token": "tok_stg456", "apiBase": "https://rollbar-staging.example.com/api/1" }
-  ]
+    { "name": "staging",  "token": "tok_stg456" }
+  ],
+  "apiBase": "https://rollbar-staging.example.com/api/1"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This MCP server implements the `stdio` server type, which means your AI tool (e.
 
 **Multiple Project: Config file (single or multiple projects)**
 
-Create `.rollbar-mcp.json` in your working directory or home directory, or set `ROLLBAR_CONFIG_FILE` to point to a custom path.
+Create `.rollbar-mcp.json` in your working directory or home directory, or set `ROLLBAR_CONFIG_FILE` to point to a custom path. A checked-in template is available at `rollbar-mcp-example.json`; copy it to `.rollbar-mcp.json` and fill in your real tokens.
 
 Single project shorthand:
 
@@ -42,6 +42,8 @@ Config file lookup order:
 3. `~/.rollbar-mcp.json` in home directory
 4. `ROLLBAR_ACCESS_TOKEN` env var (single project, backward compatible)
 
+If a config file exists but is invalid, the server exits with an error instead of falling back to a lower-priority config source.
+
 ### Tools
 
 `list-projects()`: List configured Rollbar projects (names and apiBase only; tokens are never returned). Use this when multiple projects are configured to see which project names you can pass to other tools.
@@ -56,7 +58,7 @@ Config file lookup order:
 
 `list-items(status?, level?, environment?, page?, limit?, query?, project?)`: List items filtered by status, environment, and search query. Optional `project` when multiple projects are configured.
 
-`get-replay(environment, sessionId, replayId, delivery?, project?)`: Retrieve session replay metadata and payload for a specific session. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Optional `project` when multiple projects are configured. When multiple projects are configured, direct `rollbar://replay/...` resource reads are not supported—use this tool with a `project` parameter instead. Example prompt: `Fetch the replay 789 from session abc in staging`.
+`get-replay(environment, sessionId, replayId, delivery?, project?)`: Retrieve session replay metadata and payload for a specific session. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Optional `project` when multiple projects are configured. `delivery="resource"` is only supported in single-project mode; when multiple projects are configured, use `delivery="file"` with a `project` parameter instead. Example prompt: `Fetch the replay 789 from session abc in staging`.
 
 `update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?, project?)`: Update an item's properties including status, level, title, assignment, and more. Optional `project` when multiple projects are configured. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. (Requires `write` scope)
 

--- a/README.md
+++ b/README.md
@@ -4,28 +4,61 @@ A Model Context Protocol (MCP) server for [Rollbar](https://rollbar.com).
 
 ## Features
 
-This MCP server implementes the `stdio` server type, which means your AI tool (e.g. Claude) will run it directly; you don't run a separate process or connect over http.
+This MCP server implements the `stdio` server type, which means your AI tool (e.g. Claude, Cursor) will run it directly; you don't run a separate process or connect over http.
 
 ### Configuration
 
-- `ROLLBAR_ACCESS_TOKEN`: an access token for your Rollbar project with `read` and/or `write` scope.
-- `ROLLBAR_API_BASE` (optional): override the Rollbar API base URL (defaults to `https://api.rollbar.com/api/1`). Use this when running against a staging or development Rollbar deployment.
+**Single Project: Environment variable (single project, backward compatible)**
+
+- `ROLLBAR_ACCESS_TOKEN`: access token for your Rollbar project.
+- `ROLLBAR_API_BASE` (optional): override the API base URL (defaults to `https://api.rollbar.com/api/1`).
+
+**Multiple Project: Config file (single or multiple projects)**
+
+Create `.rollbar-mcp.json` in your working directory or home directory, or set `ROLLBAR_CONFIG_FILE` to point to a custom path.
+
+Single project shorthand:
+
+```json
+{ "token": "tok_abc123" }
+```
+
+Multiple projects:
+
+```json
+{
+  "projects": [
+    { "name": "backend",  "token": "tok_abc123" },
+    { "name": "frontend", "token": "tok_xyz789" },
+    { "name": "staging",  "token": "tok_stg456", "apiBase": "https://rollbar-staging.example.com/api/1" }
+  ]
+}
+```
+
+Config file lookup order:
+
+1. `ROLLBAR_CONFIG_FILE` env var
+2. `.rollbar-mcp.json` in current working directory
+3. `~/.rollbar-mcp.json` in home directory
+4. `ROLLBAR_ACCESS_TOKEN` env var (single project, backward compatible)
 
 ### Tools
 
-`get-item-details(counter, max_tokens?)`: Given an item number, fetch the item details and last occurrence details. Supports an optional `max_tokens` parameter (default: 20000) to automatically truncate large occurrence responses. Example prompt: `Diagnose the root cause of Rollbar item #123456`
+`list-projects()`: List configured Rollbar projects (names and apiBase only; tokens are never returned). Use this when multiple projects are configured to see which project names you can pass to other tools.
 
-`get-deployments(limit)`: List deploy data for the given project. Example prompt: `List the last 5 deployments` or `Are there any failed deployments?`
+`get-item-details(counter, max_tokens?, project?)`: Given an item number, fetch the item details and last occurrence details. Supports an optional `max_tokens` parameter (default: 20000) to automatically truncate large occurrence responses. Optional `project` selects which configured project to use when multiple are defined. Example prompt: `Diagnose the root cause of Rollbar item #123456`
 
-`get-version(version, environment)`: Fetch version details for the given version string, environment name, and the configured project.
+`get-deployments(limit, project?)`: List deploy data for the given project. Optional `project` when multiple projects are configured. Example prompt: `List the last 5 deployments` or `Are there any failed deployments?`
 
-`get-top-items(environment)`: Fetch the top items in the last 24 hours given the environment name, and the configured project.
+`get-version(version, environment, project?)`: Fetch version details for the given version string and environment. Optional `project` when multiple projects are configured.
 
-`list-items(environment)`: List items filtered by status, environment and a search query.
+`get-top-items(environment, project?)`: Fetch the top items in the last 24 hours for the given environment. Optional `project` when multiple projects are configured.
 
-`get-replay(environment, sessionId, replayId, delivery?)`: Retrieve session replay metadata and payload for a specific session in the configured project. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path so any client can inspect it. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Example prompt: `Fetch the replay 789 from session abc in staging`.
+`list-items(status?, level?, environment?, page?, limit?, query?, project?)`: List items filtered by status, environment, and search query. Optional `project` when multiple projects are configured.
 
-`update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?)`: Update an item's properties including status, level, title, assignment, and more. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. (Requires `write` scope)
+`get-replay(environment, sessionId, replayId, delivery?, project?)`: Retrieve session replay metadata and payload for a specific session. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Optional `project` when multiple projects are configured. When multiple projects are configured, direct `rollbar://replay/...` resource reads are not supported—use this tool with a `project` parameter instead. Example prompt: `Fetch the replay 789 from session abc in staging`.
+
+`update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?, project?)`: Update an item's properties including status, level, title, assignment, and more. Optional `project` when multiple projects are configured. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. (Requires `write` scope)
 
 ## How to Use
 
@@ -33,18 +66,17 @@ Tested with node 20 and 22 (`nvm use 22`).
 
 ### Claude Code
 
-Configure your `.mcp.json` as follows:
+Configure your `.mcp.json` as follows.
 
-```
+Using an environment variable (single project):
+
+```json
 {
   "mcpServers": {
     "rollbar": {
       "type": "stdio",
       "command": "npx",
-      "args": [
-        "-y",
-        "@rollbar/mcp-server@latest"
-      ],
+      "args": ["-y", "@rollbar/mcp-server@latest"],
       "env": {
         "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
       }
@@ -53,58 +85,58 @@ Configure your `.mcp.json` as follows:
 }
 ```
 
-Optionally include `ROLLBAR_API_BASE` in the `env` block to target a non-production API endpoint, for example `"ROLLBAR_API_BASE": "https://rollbar-dev.example.com/api/1"`.
+Optionally include `ROLLBAR_API_BASE` in the `env` block to target a non-production API endpoint.
+
+Using a config file (single or multiple projects):
+
+```json
+{
+  "mcpServers": {
+    "rollbar": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@rollbar/mcp-server@latest"],
+      "env": {
+        "ROLLBAR_CONFIG_FILE": "/path/to/.rollbar-mcp.json"
+      }
+    }
+  }
+}
+```
 
 
 ### Codex CLI
 
 Add to your `~/.codex/config.toml`:
 
-```
+```toml
 [mcp_servers.rollbar]
 command = "npx"
 args = ["-y", "@rollbar/mcp-server@latest"]
-env = { "ROLLBAR_ACCESS_TOKEN" = "<project read/write acecss token>" }
+env = { "ROLLBAR_ACCESS_TOKEN" = "<project read/write access token>" }
+```
+
+Or with a config file:
+
+```toml
+[mcp_servers.rollbar]
+command = "npx"
+args = ["-y", "@rollbar/mcp-server@latest"]
+env = { "ROLLBAR_CONFIG_FILE" = "/path/to/.rollbar-mcp.json" }
 ```
 
 
 ### Junie
 
-Configure your `.junie/mcp/mcp.json` as follows:
+Configure your `.junie/mcp/mcp.json` as follows (env var or `ROLLBAR_CONFIG_FILE` for config file):
 
-```
+```json
 {
-    "mcpServers": {
-        "rollbar": {
-            "type": "stdio",
-            "command": "npx",
-            "args": [
-                "-y",
-                "@rollbar/mcp-server@latest"
-            ],
-            "env": {
-                "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
-            }
-        }
-    }
-}
-```
-
-
-### VS Code
-
-Configure your `.vscode/mcp.json` as follows:
-
-```
-{
-  "servers": {
+  "mcpServers": {
     "rollbar": {
       "type": "stdio",
       "command": "npx",
-      "args": [
-        "-y",
-        "@rollbar/mcp-server@latest"
-      ],
+      "args": ["-y", "@rollbar/mcp-server@latest"],
       "env": {
         "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
       }
@@ -113,4 +145,64 @@ Configure your `.vscode/mcp.json` as follows:
 }
 ```
 
-Or using a local development installation - see CONTRIBUTING.md.
+
+### Cursor
+
+Configure Cursor’s MCP servers (Cursor Settings → Features → MCP, or search for “MCP” in settings). Use either an environment variable or a config file.
+
+With an environment variable (single project):
+
+```json
+{
+  "mcpServers": {
+    "rollbar": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@rollbar/mcp-server@latest"],
+      "env": {
+        "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
+      }
+    }
+  }
+}
+```
+
+With a config file (single or multiple projects):
+
+```json
+{
+  "mcpServers": {
+    "rollbar": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@rollbar/mcp-server@latest"],
+      "env": {
+        "ROLLBAR_CONFIG_FILE": "/path/to/.rollbar-mcp.json"
+      }
+    }
+  }
+}
+```
+
+Restart Cursor (or reload the window) after changing MCP settings. To use a local build instead of npx, see CONTRIBUTING.md.
+
+### VS Code
+
+Configure your `.vscode/mcp.json` as follows (env var or `ROLLBAR_CONFIG_FILE` for config file):
+
+```json
+{
+  "servers": {
+    "rollbar": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@rollbar/mcp-server@latest"],
+      "env": {
+        "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
+      }
+    }
+  }
+}
+```
+
+Or using a local development installation—see CONTRIBUTING.md.

--- a/rollbar-mcp-example.json
+++ b/rollbar-mcp-example.json
@@ -1,0 +1,13 @@
+{
+  "projects": [
+    {
+      "name": "backend",
+      "token": "tok_backend_example",
+      "apiBase": "https://api.rollbar.com/api/1"
+    },
+    {
+      "name": "frontend",
+      "token": "tok_frontend_example"
+    }
+  ]
+}

--- a/rollbar-mcp-example.json
+++ b/rollbar-mcp-example.json
@@ -2,12 +2,12 @@
   "projects": [
     {
       "name": "backend",
-      "token": "tok_backend_example",
-      "apiBase": "https://api.rollbar.com/api/1"
+      "token": "tok_backend_example"
     },
     {
       "name": "frontend",
       "token": "tok_frontend_example"
     }
-  ]
+  ],
+  "apiBase": "https://api.rollbar.com/api/1"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,21 +11,46 @@ dotenv.config({ quiet: true } as Parameters<typeof dotenv.config>[0]);
 
 const DEFAULT_ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
 
-const ProjectConfigSchema = z.object({
-  name: z.string().min(1),
-  token: z.string().min(1),
-  apiBase: z.string().url().optional(),
-});
+const HttpUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    try {
+      const parsedUrl = new URL(value);
+      return ["https:", "http:"].includes(parsedUrl.protocol);
+    } catch {
+      return false;
+    }
+  }, "Must be a valid HTTP(S) URL");
 
-const RollbarMcpConfigSchema = z.object({
-  projects: z.array(ProjectConfigSchema).min(1),
-});
+const ProjectConfigSchema = z
+  .object({
+    name: z.string().min(1),
+    token: z.string().min(1),
+    apiBase: HttpUrlSchema.optional(),
+  })
+  .passthrough();
+
+const RollbarMcpConfigSchema = z
+  .object({
+    projects: z.array(ProjectConfigSchema).min(1),
+  })
+  .passthrough()
+  .refine((value) => !("token" in value) && !("apiBase" in value), {
+    message:
+      'Top-level "token" and "apiBase" are not allowed when "projects" is present.',
+  });
 
 // Single project shorthand (no name, no projects array)
-const RollbarMcpConfigShorthandSchema = z.object({
-  token: z.string().min(1),
-  apiBase: z.string().url().optional(),
-});
+const RollbarMcpConfigShorthandSchema = z
+  .object({
+    token: z.string().min(1),
+    apiBase: HttpUrlSchema.optional(),
+  })
+  .passthrough()
+  .refine((value) => !("projects" in value), {
+    message: '"projects" is not allowed in single-project shorthand config.',
+  });
 
 export interface ProjectConfig {
   name: string;
@@ -57,54 +82,55 @@ function normalizeApiBase(value: string | undefined): string {
   if (!value || value.length === 0) {
     return DEFAULT_ROLLBAR_API_BASE;
   }
-  const sanitized = value.replace(/\/+$/, "");
-  if (sanitized.length === 0) {
-    return DEFAULT_ROLLBAR_API_BASE;
-  }
-  try {
-    const parsedUrl = new URL(sanitized);
-    if (!["https:", "http:"].includes(parsedUrl.protocol)) {
-      return DEFAULT_ROLLBAR_API_BASE;
-    }
-    return sanitized;
-  } catch {
-    return DEFAULT_ROLLBAR_API_BASE;
-  }
+  return value.replace(/\/+$/, "");
 }
 
 function loadProjectsFromFile(filePath: string): ProjectConfig[] | null {
   if (!existsSync(filePath)) {
     return null;
   }
+
+  let json: unknown;
+
   try {
     const raw = readFileSync(filePath, "utf-8");
-    const json = JSON.parse(raw) as unknown;
-
-    // Try shorthand first
-    const shorthand = RollbarMcpConfigShorthandSchema.safeParse(json);
-    if (shorthand.success) {
-      const apiBase = normalizeApiBase(shorthand.data.apiBase);
-      return [
-        {
-          name: "default",
-          token: shorthand.data.token,
-          apiBase,
-        },
-      ];
-    }
-
-    const multi = RollbarMcpConfigSchema.safeParse(json);
-    if (multi.success) {
-      return multi.data.projects.map((p) => ({
-        name: p.name,
-        token: p.token,
-        apiBase: normalizeApiBase(p.apiBase),
-      }));
-    }
-  } catch {
-    // Invalid JSON or read error
+    json = JSON.parse(raw) as unknown;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown JSON parse error";
+    throw new Error(`Invalid Rollbar config file "${filePath}": ${message}`);
   }
-  return null;
+
+  const multi = RollbarMcpConfigSchema.safeParse(json);
+  if (multi.success) {
+    return multi.data.projects.map((p) => ({
+      name: p.name,
+      token: p.token,
+      apiBase: normalizeApiBase(p.apiBase),
+    }));
+  }
+
+  const shorthand = RollbarMcpConfigShorthandSchema.safeParse(json);
+  if (shorthand.success) {
+    const apiBase = normalizeApiBase(shorthand.data.apiBase);
+    return [
+      {
+        name: "default",
+        token: shorthand.data.token,
+        apiBase,
+      },
+    ];
+  }
+
+  throw new Error(
+    `Invalid Rollbar config file "${filePath}": expected either a single-project config like { "token": "..." } or a multi-project config like { "projects": [...] }.`,
+  );
+}
+
+function exitWithError(message: string): never {
+  console.error(message);
+  process.exit(1);
+  return undefined as never;
 }
 
 function loadConfig(): ProjectConfig[] {
@@ -114,35 +140,51 @@ function loadConfig(): ProjectConfig[] {
     const resolved = path.isAbsolute(configFileEnv)
       ? configFileEnv
       : path.resolve(process.cwd(), configFileEnv);
-    const projects = loadProjectsFromFile(resolved);
-    if (projects) {
-      return projects;
+    try {
+      const projects = loadProjectsFromFile(resolved);
+      if (projects) {
+        return projects;
+      }
+    } catch (error) {
+      return exitWithError(
+        error instanceof Error ? error.message : "Invalid Rollbar config file",
+      );
     }
-    console.error(
-      `Error: ROLLBAR_CONFIG_FILE="${configFileEnv}" not found or invalid`,
+    return exitWithError(
+      `Error: ROLLBAR_CONFIG_FILE="${configFileEnv}" was not found.`,
     );
-    process.exit(1);
   }
 
   // 2. .rollbar-mcp.json in process.cwd()
   const cwdPath = path.join(process.cwd(), ".rollbar-mcp.json");
-  const fromCwd = loadProjectsFromFile(cwdPath);
-  if (fromCwd) return fromCwd;
+  try {
+    const fromCwd = loadProjectsFromFile(cwdPath);
+    if (fromCwd) return fromCwd;
+  } catch (error) {
+    return exitWithError(
+      error instanceof Error ? error.message : "Invalid Rollbar config file",
+    );
+  }
 
   // 3. ~/.rollbar-mcp.json
   const homePath = path.join(homedir(), ".rollbar-mcp.json");
-  const fromHome = loadProjectsFromFile(homePath);
-  if (fromHome) return fromHome;
+  try {
+    const fromHome = loadProjectsFromFile(homePath);
+    if (fromHome) return fromHome;
+  } catch (error) {
+    return exitWithError(
+      error instanceof Error ? error.message : "Invalid Rollbar config file",
+    );
+  }
 
   // 4. ROLLBAR_ACCESS_TOKEN env var — synthesize single project
   const token = process.env.ROLLBAR_ACCESS_TOKEN?.trim();
   if (token && token.length > 0) {
     const apiBase = resolveApiBaseFromEnv();
     if (apiBase === null) {
-      console.error(
+      return exitWithError(
         "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
       );
-      process.exit(1);
     }
     return [
       {
@@ -153,10 +195,9 @@ function loadConfig(): ProjectConfig[] {
     ];
   }
 
-  console.error(
+  return exitWithError(
     "Error: No Rollbar configuration found. Set ROLLBAR_ACCESS_TOKEN, or create .rollbar-mcp.json (in cwd or home), or set ROLLBAR_CONFIG_FILE.",
   );
-  process.exit(1);
 }
 
 export const PROJECTS: ProjectConfig[] = loadConfig();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,48 +1,184 @@
 import dotenv from "dotenv";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
 import packageJson from "../package.json" with { type: "json" };
+import { z } from "zod";
 
 // Load environment variables from .env file
 // `quiet: true` to prevent logging to stdio which disrupts some mcp clients
-dotenv.config({ quiet: true });
+dotenv.config({ quiet: true } as Parameters<typeof dotenv.config>[0]);
 
 const DEFAULT_ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
 
-export const ROLLBAR_API_BASE = resolveRollbarApiBase();
-export function getUserAgent(toolName: string): string {
-  return `rollbar-mcp-server/${packageJson.version} (tool: ${toolName})`;
-}
-export const ROLLBAR_ACCESS_TOKEN = process.env.ROLLBAR_ACCESS_TOKEN;
+const ProjectConfigSchema = z.object({
+  name: z.string().min(1),
+  token: z.string().min(1),
+  apiBase: z.string().url().optional(),
+});
 
-if (!ROLLBAR_ACCESS_TOKEN) {
-  console.error(
-    "Error: ROLLBAR_ACCESS_TOKEN is not set in env var or .env file",
-  );
-  process.exit(1);
+const RollbarMcpConfigSchema = z.object({
+  projects: z.array(ProjectConfigSchema).min(1),
+});
+
+// Single project shorthand (no name, no projects array)
+const RollbarMcpConfigShorthandSchema = z.object({
+  token: z.string().min(1),
+  apiBase: z.string().url().optional(),
+});
+
+export interface ProjectConfig {
+  name: string;
+  token: string;
+  apiBase: string;
 }
 
-function resolveRollbarApiBase(): string {
+function resolveApiBaseFromEnv(): string | null {
   const envValue = process.env.ROLLBAR_API_BASE?.trim();
   if (!envValue || envValue.length === 0) {
     return DEFAULT_ROLLBAR_API_BASE;
   }
-
   const sanitizedValue = envValue.replace(/\/+$/, "");
-
   if (sanitizedValue.length === 0) {
-    console.error("Error: ROLLBAR_API_BASE must be a non-empty URL");
-    process.exit(1);
+    return null;
   }
-
   try {
     const parsedUrl = new URL(sanitizedValue);
     if (!["https:", "http:"].includes(parsedUrl.protocol)) {
-      throw new Error("Invalid protocol");
+      return null;
     }
     return sanitizedValue;
   } catch {
+    return null;
+  }
+}
+
+function normalizeApiBase(value: string | undefined): string {
+  if (!value || value.length === 0) {
+    return DEFAULT_ROLLBAR_API_BASE;
+  }
+  const sanitized = value.replace(/\/+$/, "");
+  if (sanitized.length === 0) {
+    return DEFAULT_ROLLBAR_API_BASE;
+  }
+  try {
+    const parsedUrl = new URL(sanitized);
+    if (!["https:", "http:"].includes(parsedUrl.protocol)) {
+      return DEFAULT_ROLLBAR_API_BASE;
+    }
+    return sanitized;
+  } catch {
+    return DEFAULT_ROLLBAR_API_BASE;
+  }
+}
+
+function loadProjectsFromFile(filePath: string): ProjectConfig[] | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const json = JSON.parse(raw) as unknown;
+
+    // Try shorthand first
+    const shorthand = RollbarMcpConfigShorthandSchema.safeParse(json);
+    if (shorthand.success) {
+      const apiBase = normalizeApiBase(shorthand.data.apiBase);
+      return [
+        {
+          name: "default",
+          token: shorthand.data.token,
+          apiBase,
+        },
+      ];
+    }
+
+    const multi = RollbarMcpConfigSchema.safeParse(json);
+    if (multi.success) {
+      return multi.data.projects.map((p) => ({
+        name: p.name,
+        token: p.token,
+        apiBase: normalizeApiBase(p.apiBase),
+      }));
+    }
+  } catch {
+    // Invalid JSON or read error
+  }
+  return null;
+}
+
+function loadConfig(): ProjectConfig[] {
+  // 1. ROLLBAR_CONFIG_FILE env var
+  const configFileEnv = process.env.ROLLBAR_CONFIG_FILE?.trim();
+  if (configFileEnv) {
+    const resolved = path.isAbsolute(configFileEnv)
+      ? configFileEnv
+      : path.resolve(process.cwd(), configFileEnv);
+    const projects = loadProjectsFromFile(resolved);
+    if (projects) {
+      return projects;
+    }
     console.error(
-      `Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL. Received "${envValue}".`,
+      `Error: ROLLBAR_CONFIG_FILE="${configFileEnv}" not found or invalid`,
     );
     process.exit(1);
   }
+
+  // 2. .rollbar-mcp.json in process.cwd()
+  const cwdPath = path.join(process.cwd(), ".rollbar-mcp.json");
+  const fromCwd = loadProjectsFromFile(cwdPath);
+  if (fromCwd) return fromCwd;
+
+  // 3. ~/.rollbar-mcp.json
+  const homePath = path.join(homedir(), ".rollbar-mcp.json");
+  const fromHome = loadProjectsFromFile(homePath);
+  if (fromHome) return fromHome;
+
+  // 4. ROLLBAR_ACCESS_TOKEN env var — synthesize single project
+  const token = process.env.ROLLBAR_ACCESS_TOKEN?.trim();
+  if (token && token.length > 0) {
+    const apiBase = resolveApiBaseFromEnv();
+    if (apiBase === null) {
+      console.error(
+        "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
+      );
+      process.exit(1);
+    }
+    return [
+      {
+        name: "default",
+        token,
+        apiBase,
+      },
+    ];
+  }
+
+  console.error(
+    "Error: No Rollbar configuration found. Set ROLLBAR_ACCESS_TOKEN, or create .rollbar-mcp.json (in cwd or home), or set ROLLBAR_CONFIG_FILE.",
+  );
+  process.exit(1);
+}
+
+export const PROJECTS: ProjectConfig[] = loadConfig();
+
+export function resolveProject(name: string | undefined): ProjectConfig {
+  if (PROJECTS.length === 1 && name === undefined) {
+    return PROJECTS[0];
+  }
+  if (name === undefined) {
+    throw new Error(
+      `Multiple projects configured. Specify a project name. Available: ${PROJECTS.map((p) => p.name).join(", ")}`,
+    );
+  }
+  const found = PROJECTS.find((p) => p.name === name);
+  if (!found) {
+    throw new Error(
+      `Unknown project "${name}". Available: ${PROJECTS.map((p) => p.name).join(", ")}`,
+    );
+  }
+  return found;
+}
+
+export function getUserAgent(toolName: string): string {
+  return `rollbar-mcp-server/${packageJson.version} (tool: ${toolName})`;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,18 +27,17 @@ const ProjectConfigSchema = z
   .object({
     name: z.string().min(1),
     token: z.string().min(1),
-    apiBase: HttpUrlSchema.optional(),
   })
   .passthrough();
 
 const RollbarMcpConfigSchema = z
   .object({
     projects: z.array(ProjectConfigSchema).min(1),
+    apiBase: HttpUrlSchema.optional(),
   })
   .passthrough()
-  .refine((value) => !("token" in value) && !("apiBase" in value), {
-    message:
-      'Top-level "token" and "apiBase" are not allowed when "projects" is present.',
+  .refine((value) => !("token" in value), {
+    message: 'Top-level "token" is not allowed when "projects" is present.',
   });
 
 // Single project shorthand (no name, no projects array)
@@ -103,10 +102,11 @@ function loadProjectsFromFile(filePath: string): ProjectConfig[] | null {
 
   const multi = RollbarMcpConfigSchema.safeParse(json);
   if (multi.success) {
+    const sharedApiBase = normalizeApiBase(multi.data.apiBase);
     return multi.data.projects.map((p) => ({
       name: p.name,
       token: p.token,
-      apiBase: normalizeApiBase(p.apiBase),
+      apiBase: sharedApiBase,
     }));
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,44 +6,18 @@ import { registerAllTools } from "./tools/index.js";
 import { registerAllResources } from "./resources/index.js";
 
 // Create server instance
-const server = new McpServer({
-  name: "rollbar",
-  version: "0.0.1",
-  capabilities: {
-    resources: {},
-    tools: {
-      "get-item-details": {
-        description:
-          "Get detailed information about a Rollbar item by its counter",
-      },
-      "get-deployments": {
-        description:
-          "Get deployment status and information for a Rollbar project",
-      },
-      "get-version": {
-        description: "Get version data and information for a Rollbar project",
-      },
-      "get-top-items": {
-        description: "Get list of top items in the Rollbar project",
-      },
-      "list-items": {
-        description:
-          "List all items in the Rollbar project with optional search and filtering",
-      },
-      "get-replay": {
-        description: "Get replay data for a specific session replay in Rollbar",
-      },
-      "list-projects": {
-        description:
-          "List configured Rollbar projects available in this MCP server",
-      },
-      "update-item": {
-        description:
-          "Update the status, level, title, or assignment of a Rollbar item",
-      },
+const server = new McpServer(
+  {
+    name: "rollbar",
+    version: "0.0.1",
+  },
+  {
+    capabilities: {
+      resources: {},
+      tools: {},
     },
   },
-});
+);
 
 // Register all tools
 registerAllResources(server);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,14 @@ const server = new McpServer({
       "get-replay": {
         description: "Get replay data for a specific session replay in Rollbar",
       },
+      "list-projects": {
+        description:
+          "List configured Rollbar projects available in this MCP server",
+      },
+      "update-item": {
+        description:
+          "Update the status, level, title, or assignment of a Rollbar item",
+      },
     },
   },
 });

--- a/src/resources/replay-resource.ts
+++ b/src/resources/replay-resource.ts
@@ -3,7 +3,7 @@ import type {
   McpServer,
   ReadResourceTemplateCallback,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { PROJECTS, resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { RollbarApiResponse } from "../types/index.js";
 
@@ -33,11 +33,12 @@ function normalizeTemplateVariable(
 }
 
 function buildReplayApiUrl(
+  apiBase: string,
   environment: string,
   sessionId: string,
   replayId: string,
 ): string {
-  return `${ROLLBAR_API_BASE}/environment/${encodeURIComponent(
+  return `${apiBase}/environment/${encodeURIComponent(
     environment,
   )}/session/${encodeURIComponent(sessionId)}/replay/${encodeURIComponent(
     replayId,
@@ -76,12 +77,20 @@ export async function fetchReplayData(
   environment: string,
   sessionId: string,
   replayId: string,
+  token: string,
+  apiBase: string,
 ): Promise<unknown> {
-  const replayUrl = buildReplayApiUrl(environment, sessionId, replayId);
+  const replayUrl = buildReplayApiUrl(
+    apiBase,
+    environment,
+    sessionId,
+    replayId,
+  );
 
   const replayResponse = await makeRollbarRequest<RollbarApiResponse<unknown>>(
     replayUrl,
     "get-replay",
+    token,
   );
 
   if (replayResponse.err !== 0) {
@@ -97,6 +106,14 @@ const readReplayResource: ReadResourceTemplateCallback = async (
   uri,
   variables,
 ) => {
+  if (PROJECTS.length > 1) {
+    throw new Error(
+      "Direct replay resource access is not supported when multiple projects are configured. " +
+        "Use the get-replay tool with a project parameter instead.",
+    );
+  }
+  const { token, apiBase } = resolveProject(undefined);
+
   const environmentValue = normalizeTemplateVariable(variables.environment);
   const sessionValue = normalizeTemplateVariable(variables.sessionId);
   const replayValue = normalizeTemplateVariable(variables.replayId);
@@ -117,7 +134,7 @@ const readReplayResource: ReadResourceTemplateCallback = async (
   const replayData =
     cached !== undefined
       ? cached
-      : await fetchReplayData(environment, sessionId, replayId);
+      : await fetchReplayData(environment, sessionId, replayId, token, apiBase);
 
   if (cached === undefined) {
     cacheReplayData(resourceUri, replayData);

--- a/src/tools/get-deployments.ts
+++ b/src/tools/get-deployments.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import { RollbarApiResponse, RollbarDeployResponse } from "../types/index.js";
 
 export function registerGetDeploymentsTool(server: McpServer) {
@@ -13,12 +14,14 @@ export function registerGetDeploymentsTool(server: McpServer) {
         .number()
         .int()
         .describe("Number of Rollbar deployments to retrieve"),
+      project: buildProjectParam(),
     },
-    async ({ limit }) => {
-      const deploysUrl = `${ROLLBAR_API_BASE}/deploys?limit=${limit}`;
+    async ({ limit, project }) => {
+      const { token, apiBase } = resolveProject(project);
+      const deploysUrl = `${apiBase}/deploys?limit=${limit}`;
       const deploysResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarDeployResponse>
-      >(deploysUrl, "get-deployments");
+      >(deploysUrl, "get-deployments", token);
 
       if (deploysResponse.err !== 0) {
         const errorMessage =

--- a/src/tools/get-item-details.ts
+++ b/src/tools/get-item-details.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import {
   RollbarApiResponse,
   RollbarItemResponse,
@@ -23,13 +24,15 @@ export function registerGetItemDetailsTool(server: McpServer) {
         .describe(
           "Maximum tokens for occurrence data in response (default: 20000). Occurrence response will be truncated if it exceeds this limit.",
         ),
+      project: buildProjectParam(),
     },
-    async ({ counter, max_tokens }) => {
+    async ({ counter, max_tokens, project }) => {
+      const { token, apiBase } = resolveProject(project);
       // Redirects are followed, so we get an item response from the counter request
-      const counterUrl = `${ROLLBAR_API_BASE}/item_by_counter/${counter}`;
+      const counterUrl = `${apiBase}/item_by_counter/${counter}`;
       const itemResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarItemResponse>
-      >(counterUrl, "get-item-details");
+      >(counterUrl, "get-item-details", token);
 
       if (itemResponse.err !== 0) {
         const errorMessage =
@@ -39,10 +42,10 @@ export function registerGetItemDetailsTool(server: McpServer) {
 
       const item = itemResponse.result;
 
-      const occurrenceUrl = `${ROLLBAR_API_BASE}/instance/${item.last_occurrence_id}`;
+      const occurrenceUrl = `${apiBase}/instance/${item.last_occurrence_id}`;
       const occurrenceResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarOccurrenceResponse>
-      >(occurrenceUrl, "get-item-details");
+      >(occurrenceUrl, "get-item-details", token);
 
       if (occurrenceResponse.err !== 0) {
         // We got the item but failed to get occurrence. Return just the item data.

--- a/src/tools/get-replay.ts
+++ b/src/tools/get-replay.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { resolveProject } from "../config.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import {
   buildReplayResourceUri,
   cacheReplayData,
@@ -68,14 +70,18 @@ export function registerGetReplayTool(server: McpServer) {
       delivery: DELIVERY_MODE.optional().describe(
         "How to return the replay payload. Defaults to 'file' (writes JSON to a temp file); 'resource' returns a rollbar:// link.",
       ),
+      project: buildProjectParam(),
     },
-    async ({ environment, sessionId, replayId, delivery }) => {
+    async ({ environment, sessionId, replayId, delivery, project }) => {
       const deliveryMode = delivery ?? "file";
+      const { token, apiBase } = resolveProject(project);
 
       const replayData = await fetchReplayData(
         environment,
         sessionId,
         replayId,
+        token,
+        apiBase,
       );
 
       const resourceUri = buildReplayResourceUri(

--- a/src/tools/get-replay.ts
+++ b/src/tools/get-replay.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { PROJECTS, resolveProject } from "../config.js";
 import { buildProjectParam } from "../utils/project-params.js";
 import {
   buildReplayResourceUri,
@@ -75,6 +75,12 @@ export function registerGetReplayTool(server: McpServer) {
     async ({ environment, sessionId, replayId, delivery, project }) => {
       const deliveryMode = delivery ?? "file";
       const { token, apiBase } = resolveProject(project);
+
+      if (deliveryMode === "resource" && PROJECTS.length > 1) {
+        throw new Error(
+          'delivery="resource" is not supported when multiple projects are configured. Use delivery="file" and specify the project parameter instead.',
+        );
+      }
 
       const replayData = await fetchReplayData(
         environment,

--- a/src/tools/get-top-items.ts
+++ b/src/tools/get-top-items.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import { RollbarApiResponse, RollbarTopItemResponse } from "../types/index.js";
 
 export function registerGetTopItemsTool(server: McpServer) {
@@ -13,12 +14,14 @@ export function registerGetTopItemsTool(server: McpServer) {
         .string()
         .default("production")
         .describe("Environment name (default: production)"),
+      project: buildProjectParam(),
     },
-    async ({ environment }) => {
-      const reportUrl = `${ROLLBAR_API_BASE}/reports/top_active_items?hours=24&environments=${environment}&sort=occurrences`;
+    async ({ environment, project }) => {
+      const { token, apiBase } = resolveProject(project);
+      const reportUrl = `${apiBase}/reports/top_active_items?hours=24&environments=${environment}&sort=occurrences`;
       const reportResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarTopItemResponse>
-      >(reportUrl, "get-top-items");
+      >(reportUrl, "get-top-items", token);
 
       if (reportResponse.err !== 0) {
         const errorMessage =

--- a/src/tools/get-version.ts
+++ b/src/tools/get-version.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import { RollbarApiResponse, RollbarVersionsResponse } from "../types/index.js";
 
 export function registerGetVersionTool(server: McpServer) {
@@ -14,12 +15,14 @@ export function registerGetVersionTool(server: McpServer) {
         .string()
         .default("production")
         .describe("Environment name (default: production)"),
+      project: buildProjectParam(),
     },
-    async ({ version, environment }) => {
-      const versionsUrl = `${ROLLBAR_API_BASE}/versions/${version}?environment=${environment}`;
+    async ({ version, environment, project }) => {
+      const { token, apiBase } = resolveProject(project);
+      const versionsUrl = `${apiBase}/versions/${version}?environment=${environment}`;
       const versionsResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarVersionsResponse>
-      >(versionsUrl, "get-version");
+      >(versionsUrl, "get-version", token);
 
       if (versionsResponse.err !== 0) {
         const errorMessage =

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import { registerGetTopItemsTool } from "./get-top-items.js";
 import { registerListItemsTool } from "./list-items.js";
 import { registerUpdateItemTool } from "./update-item.js";
 import { registerGetReplayTool } from "./get-replay.js";
+import { registerListProjectsTool } from "./list-projects.js";
 
 export function registerAllTools(server: McpServer) {
   registerGetItemDetailsTool(server);
@@ -15,4 +16,5 @@ export function registerAllTools(server: McpServer) {
   registerListItemsTool(server);
   registerUpdateItemTool(server);
   registerGetReplayTool(server);
+  registerListProjectsTool(server);
 }

--- a/src/tools/list-items.ts
+++ b/src/tools/list-items.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import {
   RollbarApiResponse,
   RollbarListItemsResponse,
@@ -51,6 +52,7 @@ export function registerListItemsTool(server: McpServer) {
         .string()
         .optional()
         .describe("Search query to filter items by title or content"),
+      project: buildProjectParam(),
     },
     async ({
       status,
@@ -59,6 +61,7 @@ export function registerListItemsTool(server: McpServer) {
       page,
       limit,
       query,
+      project,
     }: {
       status?: string;
       level?: string[];
@@ -66,7 +69,9 @@ export function registerListItemsTool(server: McpServer) {
       page?: number;
       limit?: number;
       query?: string;
+      project?: string;
     }) => {
+      const { token, apiBase } = resolveProject(project);
       // Build query parameters
       const params = new URLSearchParams();
 
@@ -94,11 +99,11 @@ export function registerListItemsTool(server: McpServer) {
         params.append("q", query);
       }
 
-      const listUrl = `${ROLLBAR_API_BASE}/items/?${params.toString()}`;
+      const listUrl = `${apiBase}/items/?${params.toString()}`;
 
       const listResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarListItemsResponse>
-      >(listUrl, "list-items");
+      >(listUrl, "list-items", token);
 
       if (listResponse.err !== 0) {
         const errorMessage =

--- a/src/tools/list-projects.ts
+++ b/src/tools/list-projects.ts
@@ -1,0 +1,19 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { PROJECTS } from "../config.js";
+
+export function registerListProjectsTool(server: McpServer) {
+  server.tool(
+    "list-projects",
+    "List configured Rollbar projects available to this MCP server",
+    {},
+    () => {
+      const projects = PROJECTS.map((p) => ({
+        name: p.name,
+        apiBase: p.apiBase,
+      }));
+      return {
+        content: [{ type: "text", text: JSON.stringify(projects) }],
+      };
+    },
+  );
+}

--- a/src/tools/update-item.ts
+++ b/src/tools/update-item.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { ROLLBAR_API_BASE } from "../config.js";
+import { resolveProject } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { buildProjectParam } from "../utils/project-params.js";
 import { RollbarApiResponse } from "../types/index.js";
 
 export function registerUpdateItemTool(server: McpServer) {
@@ -39,6 +40,7 @@ export function registerUpdateItemTool(server: McpServer) {
         .describe(
           "The ID of the team to assign as owner (Advanced/Enterprise accounts only)",
         ),
+      project: buildProjectParam(),
     },
     async ({
       itemId,
@@ -49,7 +51,9 @@ export function registerUpdateItemTool(server: McpServer) {
       resolvedInVersion,
       snoozed,
       teamId,
+      project,
     }) => {
+      const { token, apiBase } = resolveProject(project);
       const updateData: Record<string, unknown> = {};
 
       if (status !== undefined) updateData.status = status;
@@ -66,10 +70,11 @@ export function registerUpdateItemTool(server: McpServer) {
         throw new Error("At least one field must be provided to update");
       }
 
-      const url = `${ROLLBAR_API_BASE}/item/${itemId}`;
+      const url = `${apiBase}/item/${itemId}`;
       const response = await makeRollbarRequest<RollbarApiResponse<unknown>>(
         url,
         "update-item",
+        token,
         {
           method: "PATCH",
           headers: {

--- a/src/types/rollbar-truncation.d.ts
+++ b/src/types/rollbar-truncation.d.ts
@@ -1,0 +1,10 @@
+declare module "rollbar/src/truncation" {
+  const truncation: {
+    truncate: (
+      payload: unknown,
+      jsonBackup: typeof JSON.stringify,
+      maxSize: number,
+    ) => { error?: Error; value: string };
+  };
+  export default truncation;
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,18 +1,15 @@
-import { ROLLBAR_ACCESS_TOKEN, getUserAgent } from "../config.js";
+import { getUserAgent } from "../config.js";
 
 // Helper function for making Rollbar API requests
 export async function makeRollbarRequest<T>(
   url: string,
   toolName: string,
+  token: string,
   options?: RequestInit,
 ): Promise<T> {
-  if (!ROLLBAR_ACCESS_TOKEN) {
-    throw new Error("ROLLBAR_ACCESS_TOKEN environment variable is not set");
-  }
-
   const headers = {
     "User-Agent": getUserAgent(toolName),
-    "X-Rollbar-Access-Token": ROLLBAR_ACCESS_TOKEN,
+    "X-Rollbar-Access-Token": token,
     Accept: "application/json",
     ...options?.headers,
   };

--- a/src/utils/project-params.ts
+++ b/src/utils/project-params.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { PROJECTS } from "../config.js";
+
+export function buildProjectParam() {
+  if (PROJECTS.length === 1) {
+    return z
+      .string()
+      .optional()
+      .describe("Project name (optional when only one project is configured)");
+  }
+  const names = PROJECTS.map((p) => p.name) as [string, ...string[]];
+  return z.enum(names).describe(`Project name. One of: ${names.join(", ")}`);
+}

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -40,7 +40,9 @@ describe('MCP Server Integration', () => {
       start: vi.fn(),
       close: vi.fn()
     };
-    (StdioServerTransport as any).mockImplementation(() => mockTransport);
+    (StdioServerTransport as any).mockImplementation(function () {
+      return mockTransport;
+    });
   });
 
   afterEach(() => {

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -3,11 +3,21 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerAllTools } from '../../src/tools/index.js';
 
-// Mock the config to provide ROLLBAR_ACCESS_TOKEN
+// Mock the config to provide PROJECTS and resolveProject
 vi.mock('../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  USER_AGENT: 'rollbar-mcp-server/0.0.1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 // Mock the transport
@@ -83,7 +93,7 @@ describe('MCP Server Integration', () => {
     const toolSpy = vi.spyOn(server, 'tool');
     registerAllTools(server);
 
-    expect(toolSpy).toHaveBeenCalledTimes(7);
+    expect(toolSpy).toHaveBeenCalledTimes(8);
     expect(toolSpy).toHaveBeenCalledWith(
       'get-item-details',
       expect.any(String),
@@ -122,6 +132,12 @@ describe('MCP Server Integration', () => {
     );
     expect(toolSpy).toHaveBeenCalledWith(
       'get-replay',
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function)
+    );
+    expect(toolSpy).toHaveBeenCalledWith(
+      'list-projects',
       expect.any(String),
       expect.any(Object),
       expect.any(Function)
@@ -337,6 +353,15 @@ describe('MCP Server Integration', () => {
         },
         'list-items': {
           description: 'List all items in the Rollbar project with optional search and filtering'
+        },
+        'update-item': {
+          description: 'Update the status, level, title, or assignment of a Rollbar item'
+        },
+        'get-replay': {
+          description: 'Get replay data for a specific session replay in Rollbar'
+        },
+        'list-projects': {
+          description: 'List configured Rollbar projects available in this MCP server'
         }
       }
     };
@@ -350,7 +375,7 @@ describe('MCP Server Integration', () => {
     server = new McpServer(config);
 
     expect(capabilities).toEqual(capabilities);
-    expect(Object.keys(capabilities.tools)).toHaveLength(5);
+    expect(Object.keys(capabilities.tools)).toHaveLength(8);
 
     // Verify all tools have descriptions
     Object.values(capabilities.tools).forEach(tool => {

--- a/tests/unit/config.vitest.test.ts
+++ b/tests/unit/config.vitest.test.ts
@@ -1,21 +1,32 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock('dotenv', () => ({
+vi.mock("dotenv", () => ({
   default: {
-    config: vi.fn()
-  }
+    config: vi.fn(),
+  },
 }));
 
-describe('config', () => {
+const existsSyncMock = vi.fn();
+const readFileSyncMock = vi.fn();
+vi.mock("node:fs", () => ({
+  existsSync: (path: string) => existsSyncMock(path),
+  readFileSync: (path: string, ...args: unknown[]) =>
+    readFileSyncMock(path, ...args),
+}));
+
+describe("config", () => {
   const originalEnv = process.env;
   const originalExit = process.exit;
   const originalConsoleError = console.error;
 
   beforeEach(() => {
-    process.env = { ...originalEnv, ROLLBAR_ACCESS_TOKEN: 'test-token' };
+    process.env = { ...originalEnv, ROLLBAR_ACCESS_TOKEN: "test-token" };
     delete process.env.ROLLBAR_API_BASE;
-    process.exit = vi.fn() as any;
+    delete process.env.ROLLBAR_CONFIG_FILE;
+    process.exit = vi.fn() as typeof process.exit;
     console.error = vi.fn();
+    existsSyncMock.mockReturnValue(false);
+    readFileSyncMock.mockReset();
     vi.resetModules();
   });
 
@@ -26,60 +37,227 @@ describe('config', () => {
     vi.clearAllMocks();
   });
 
-  it('should have correct API base URL', async () => {
-    const { ROLLBAR_API_BASE } = await import('../../src/config.js');
-    expect(ROLLBAR_API_BASE).toBe('https://api.rollbar.com/api/1');
+  it("should have correct apiBase when using env token", async () => {
+    const { PROJECTS, resolveProject } = await import("../../src/config.js");
+    expect(PROJECTS).toHaveLength(1);
+    expect(PROJECTS[0].apiBase).toBe("https://api.rollbar.com/api/1");
+    expect(resolveProject(undefined).apiBase).toBe(
+      "https://api.rollbar.com/api/1",
+    );
   });
 
-  it('should allow overriding API base URL via environment variable', async () => {
-    process.env.ROLLBAR_API_BASE = 'https://rollbar-dev.example.com/api/1/';
+  it("should allow overriding API base URL via environment variable", async () => {
+    process.env.ROLLBAR_API_BASE = "https://rollbar-dev.example.com/api/1/";
     vi.resetModules();
-    const { ROLLBAR_API_BASE } = await import('../../src/config.js');
-    expect(ROLLBAR_API_BASE).toBe('https://rollbar-dev.example.com/api/1');
+    const { PROJECTS } = await import("../../src/config.js");
+    expect(PROJECTS[0].apiBase).toBe("https://rollbar-dev.example.com/api/1");
   });
 
-  it('should have getUserAgent function that generates correct user agent string', async () => {
-    const { getUserAgent } = await import('../../src/config.js');
-    const packageJsonModule = await import('../../package.json', { with: { type: 'json' } });
+  it("should have getUserAgent function that generates correct user agent string", async () => {
+    const { getUserAgent } = await import("../../src/config.js");
+    const packageJsonModule = await import("../../package.json", {
+      with: { type: "json" },
+    });
     const expectedVersion = packageJsonModule.default.version;
-    expect(getUserAgent('test-tool')).toBe(`rollbar-mcp-server/${expectedVersion} (tool: test-tool)`);
+    expect(getUserAgent("test-tool")).toBe(
+      `rollbar-mcp-server/${expectedVersion} (tool: test-tool)`,
+    );
   });
 
-  it('should load access token from environment', async () => {
-    process.env.ROLLBAR_ACCESS_TOKEN = 'custom-token';
-    const { ROLLBAR_ACCESS_TOKEN } = await import('../../src/config.js');
-    expect(ROLLBAR_ACCESS_TOKEN).toBe('custom-token');
+  it("should load token from environment and resolveProject returns it", async () => {
+    process.env.ROLLBAR_ACCESS_TOKEN = "custom-token";
+    vi.resetModules();
+    const { resolveProject } = await import("../../src/config.js");
+    expect(resolveProject(undefined).token).toBe("custom-token");
   });
 
-  it('should exit when ROLLBAR_ACCESS_TOKEN is missing', async () => {
+  it("should exit when neither config file nor env var is set", async () => {
     delete process.env.ROLLBAR_ACCESS_TOKEN;
-    
-    await import('../../src/config.js');
+    existsSyncMock.mockReturnValue(false);
+
+    await import("../../src/config.js");
 
     expect(console.error).toHaveBeenCalledWith(
-      'Error: ROLLBAR_ACCESS_TOKEN is not set in env var or .env file'
+      expect.stringContaining("No Rollbar configuration found"),
     );
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('should exit when ROLLBAR_API_BASE is invalid', async () => {
-    process.env.ROLLBAR_API_BASE = 'not-a-valid-url';
+  it("should exit when ROLLBAR_API_BASE is invalid and using env token", async () => {
+    process.env.ROLLBAR_API_BASE = "not-a-valid-url";
     vi.resetModules();
 
-    await import('../../src/config.js');
+    await import("../../src/config.js");
 
     expect(console.error).toHaveBeenCalledWith(
-      'Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL. Received "not-a-valid-url".'
+      "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
     );
     expect(process.exit).toHaveBeenCalledWith(1);
   });
 
-  it('should call dotenv.config() on module load', async () => {
-    const dotenv = await import('dotenv');
+  it("should call dotenv.config() on module load", async () => {
+    const dotenv = await import("dotenv");
     vi.clearAllMocks();
-    
-    await import('../../src/config.js');
-    
+
+    await import("../../src/config.js");
+
     expect(dotenv.default.config).toHaveBeenCalled();
+  });
+
+  it("loads JSON config from ROLLBAR_CONFIG_FILE path", async () => {
+    process.env.ROLLBAR_CONFIG_FILE = "/custom/config.json";
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) => p === "/custom/config.json");
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        projects: [
+          {
+            name: "backend",
+            token: "tok_abc",
+            apiBase: "https://api.example.com/api/1",
+          },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    const { PROJECTS } = await import("../../src/config.js");
+
+    expect(PROJECTS).toHaveLength(1);
+    expect(PROJECTS[0].name).toBe("backend");
+    expect(PROJECTS[0].token).toBe("tok_abc");
+    expect(PROJECTS[0].apiBase).toBe("https://api.example.com/api/1");
+  });
+
+  it("accepts multi-project config and sets PROJECTS with correct name/token/apiBase", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        projects: [
+          { name: "backend", token: "tok_1" },
+          {
+            name: "staging",
+            token: "tok_2",
+            apiBase: "https://staging.rollbar.com/api/1",
+          },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    const { PROJECTS } = await import("../../src/config.js");
+
+    expect(PROJECTS).toHaveLength(2);
+    expect(PROJECTS[0]).toEqual({
+      name: "backend",
+      token: "tok_1",
+      apiBase: "https://api.rollbar.com/api/1",
+    });
+    expect(PROJECTS[1]).toEqual({
+      name: "staging",
+      token: "tok_2",
+      apiBase: "https://staging.rollbar.com/api/1",
+    });
+  });
+
+  it("accepts shorthand config { token } and synthesizes name default", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(JSON.stringify({ token: "tok_single" }));
+    vi.resetModules();
+
+    const { PROJECTS } = await import("../../src/config.js");
+
+    expect(PROJECTS).toHaveLength(1);
+    expect(PROJECTS[0].name).toBe("default");
+    expect(PROJECTS[0].token).toBe("tok_single");
+    expect(PROJECTS[0].apiBase).toBe("https://api.rollbar.com/api/1");
+  });
+
+  it("falls back to ROLLBAR_ACCESS_TOKEN when no config file is present", async () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const { PROJECTS, resolveProject } = await import("../../src/config.js");
+
+    expect(PROJECTS).toHaveLength(1);
+    expect(PROJECTS[0].name).toBe("default");
+    expect(resolveProject(undefined).token).toBe("test-token");
+  });
+
+  it("resolveProject(undefined) returns the only project when PROJECTS.length === 1", async () => {
+    const { resolveProject } = await import("../../src/config.js");
+    const project = resolveProject(undefined);
+    expect(project.name).toBe("default");
+    expect(project.token).toBe("test-token");
+  });
+
+  it("resolveProject('backend') returns the correct project by name", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        projects: [
+          { name: "backend", token: "tok_backend" },
+          { name: "frontend", token: "tok_frontend" },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    const { resolveProject } = await import("../../src/config.js");
+
+    expect(resolveProject("backend").token).toBe("tok_backend");
+    expect(resolveProject("frontend").token).toBe("tok_frontend");
+  });
+
+  it("resolveProject(undefined) throws when PROJECTS.length > 1", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        projects: [
+          { name: "backend", token: "tok_1" },
+          { name: "frontend", token: "tok_2" },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    const { resolveProject } = await import("../../src/config.js");
+
+    expect(() => resolveProject(undefined)).toThrow(
+      /Multiple projects configured. Specify a project name/,
+    );
+    expect(() => resolveProject(undefined)).toThrow(/backend.*frontend/);
+  });
+
+  it("resolveProject('nonexistent') throws with list of valid names", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        projects: [
+          { name: "backend", token: "tok_1" },
+          { name: "frontend", token: "tok_2" },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    const { resolveProject } = await import("../../src/config.js");
+
+    expect(() => resolveProject("nonexistent")).toThrow(/Unknown project/);
+    expect(() => resolveProject("nonexistent")).toThrow(/backend.*frontend/);
   });
 });

--- a/tests/unit/config.vitest.test.ts
+++ b/tests/unit/config.vitest.test.ts
@@ -110,11 +110,11 @@ describe("config", () => {
     existsSyncMock.mockImplementation((p: string) => p === "/custom/config.json");
     readFileSyncMock.mockReturnValue(
       JSON.stringify({
+        apiBase: "https://api.example.com/api/1",
         projects: [
           {
             name: "backend",
             token: "tok_abc",
-            apiBase: "https://api.example.com/api/1",
           },
         ],
       }),
@@ -151,13 +151,10 @@ describe("config", () => {
     );
     readFileSyncMock.mockReturnValue(
       JSON.stringify({
+        apiBase: "https://staging.rollbar.com/api/1",
         projects: [
           { name: "backend", token: "tok_1" },
-          {
-            name: "staging",
-            token: "tok_2",
-            apiBase: "https://staging.rollbar.com/api/1",
-          },
+          { name: "staging", token: "tok_2" },
         ],
       }),
     );
@@ -169,7 +166,7 @@ describe("config", () => {
     expect(PROJECTS[0]).toEqual({
       name: "backend",
       token: "tok_1",
-      apiBase: "https://api.rollbar.com/api/1",
+      apiBase: "https://staging.rollbar.com/api/1",
     });
     expect(PROJECTS[1]).toEqual({
       name: "staging",
@@ -231,11 +228,11 @@ describe("config", () => {
     );
     readFileSyncMock.mockReturnValue(
       JSON.stringify({
+        apiBase: "ftp://example.com/api/1",
         projects: [
           {
             name: "backend",
             token: "tok_backend",
-            apiBase: "ftp://example.com/api/1",
           },
         ],
       }),

--- a/tests/unit/config.vitest.test.ts
+++ b/tests/unit/config.vitest.test.ts
@@ -129,6 +129,21 @@ describe("config", () => {
     expect(PROJECTS[0].apiBase).toBe("https://api.example.com/api/1");
   });
 
+  it("should exit when ROLLBAR_CONFIG_FILE points to invalid JSON", async () => {
+    process.env.ROLLBAR_CONFIG_FILE = "/custom/config.json";
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) => p === "/custom/config.json");
+    readFileSyncMock.mockReturnValue("{ invalid json");
+    vi.resetModules();
+
+    await import("../../src/config.js");
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid Rollbar config file "/custom/config.json"'),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
   it("accepts multi-project config and sets PROJECTS with correct name/token/apiBase", async () => {
     delete process.env.ROLLBAR_ACCESS_TOKEN;
     existsSyncMock.mockImplementation((p: string) =>
@@ -177,6 +192,110 @@ describe("config", () => {
     expect(PROJECTS[0].name).toBe("default");
     expect(PROJECTS[0].token).toBe("tok_single");
     expect(PROJECTS[0].apiBase).toBe("https://api.rollbar.com/api/1");
+  });
+
+  it("accepts harmless extra metadata keys in config files", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        description: "internal metadata",
+        projects: [
+          {
+            name: "backend",
+            token: "tok_backend",
+            environment: "production",
+            internalId: 123,
+          },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    const { PROJECTS } = await import("../../src/config.js");
+
+    expect(PROJECTS).toHaveLength(1);
+    expect(PROJECTS[0]).toEqual({
+      name: "backend",
+      token: "tok_backend",
+      apiBase: "https://api.rollbar.com/api/1",
+    });
+  });
+
+  it("should exit when config apiBase is not HTTP(S)", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) =>
+      p.endsWith(".rollbar-mcp.json"),
+    );
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        projects: [
+          {
+            name: "backend",
+            token: "tok_backend",
+            apiBase: "ftp://example.com/api/1",
+          },
+        ],
+      }),
+    );
+    vi.resetModules();
+
+    await import("../../src/config.js");
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid Rollbar config file"),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should exit when cwd config exists but is invalid instead of falling back to env", async () => {
+    existsSyncMock.mockImplementation((p: string) => p.endsWith(".rollbar-mcp.json"));
+    readFileSyncMock.mockReturnValue(JSON.stringify({ projects: "not-an-array" }));
+    vi.resetModules();
+
+    await import("../../src/config.js");
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid Rollbar config file"),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should exit when home config exists but is invalid instead of falling back to env", async () => {
+    existsSyncMock.mockImplementation(
+      (p: string) =>
+        p.endsWith(".rollbar-mcp.json") && !p.startsWith(process.cwd()),
+    );
+    readFileSyncMock.mockReturnValue("{ invalid json");
+    vi.resetModules();
+
+    await import("../../src/config.js");
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid Rollbar config file"),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("should exit when shorthand and multi-project fields are both present", async () => {
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    existsSyncMock.mockImplementation((p: string) => p.endsWith(".rollbar-mcp.json"));
+    readFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        token: "tok_single",
+        projects: [{ name: "backend", token: "tok_backend" }],
+      }),
+    );
+    vi.resetModules();
+
+    await import("../../src/config.js");
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("expected either a single-project config"),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
   });
 
   it("falls back to ROLLBAR_ACCESS_TOKEN when no config file is present", async () => {

--- a/tests/unit/resources/replay-resource.test.ts
+++ b/tests/unit/resources/replay-resource.test.ts
@@ -8,8 +8,18 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
 }));
 
 let makeRollbarRequestMock: any;
@@ -137,5 +147,33 @@ describe('read replay resource handler', () => {
         replayId
       })
     ).rejects.toThrow('Invalid replay resource URI');
+  });
+
+  it('throws when PROJECTS.length > 1 with message to use get-replay tool', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      PROJECTS: [
+        { name: 'backend', token: 't1', apiBase: 'https://api.rollbar.com/api/1' },
+        { name: 'frontend', token: 't2', apiBase: 'https://api.rollbar.com/api/1' },
+      ],
+      resolveProject: vi.fn(),
+    }));
+    const replayMod = await import('../../../src/resources/replay-resource.js');
+    let multiProjectReadCallback: typeof readCallback;
+    const resourceSpy2 = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
+      multiProjectReadCallback = handler as typeof readCallback;
+    });
+    const server2 = { resource: resourceSpy2 } as any;
+    replayMod.registerReplayResource(server2);
+
+    const uri = new URL(replayUri);
+    await expect(
+      multiProjectReadCallback!(uri, { environment, sessionId, replayId })
+    ).rejects.toThrow(
+      'Direct replay resource access is not supported when multiple projects are configured'
+    );
+    await expect(
+      multiProjectReadCallback!(uri, { environment, sessionId, replayId })
+    ).rejects.toThrow('get-replay tool');
   });
 });

--- a/tests/unit/tools/get-deployments.test.ts
+++ b/tests/unit/tools/get-deployments.test.ts
@@ -8,8 +8,19 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 describe('get-deployments tool', () => {
@@ -40,7 +51,8 @@ describe('get-deployments tool', () => {
       'get-deployments',
       'Get deployments data from Rollbar',
       expect.objectContaining({
-        limit: expect.any(Object)
+        limit: expect.any(Object),
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -53,7 +65,8 @@ describe('get-deployments tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/deploys?limit=10',
-      'get-deployments'
+      'get-deployments',
+      'test-token'
     );
     expect(result.content[0].type).toBe('text');
     const parsed = JSON.parse(result.content[0].text);
@@ -80,7 +93,8 @@ describe('get-deployments tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/deploys?limit=20',
-      'get-deployments'
+      'get-deployments',
+      'test-token'
     );
   });
 
@@ -107,6 +121,20 @@ describe('get-deployments tool', () => {
     expect(() => schema.limit.parse(3.14)).toThrow();
     expect(() => schema.limit.parse('10')).toThrow();
     expect(() => schema.limit.parse(null)).toThrow();
+  });
+
+  it('should work with explicit project default', async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulDeployResponse);
+
+    const result = await toolHandler({ limit: 10, project: 'default' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/deploys?limit=10',
+      'get-deployments',
+      'test-token'
+    );
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.environment).toBe('production');
   });
 
   it('should format response as compact JSON', async () => {

--- a/tests/unit/tools/get-item-details.test.ts
+++ b/tests/unit/tools/get-item-details.test.ts
@@ -8,8 +8,19 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 vi.mock('../../../src/utils/truncation.js', () => ({
@@ -60,7 +71,8 @@ describe('get-item-details tool', () => {
       'Get item details for a Rollbar item',
       expect.objectContaining({
         counter: expect.any(Object),
-        max_tokens: expect.any(Object)
+        max_tokens: expect.any(Object),
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -71,15 +83,17 @@ describe('get-item-details tool', () => {
       .mockResolvedValueOnce(mockSuccessfulItemResponse)
       .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
 
-    const result = await toolHandler({ counter: 42 });
+    const result = await toolHandler({ counter: 42, project: undefined });
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/item_by_counter/42',
-      'get-item-details'
+      'get-item-details',
+      'test-token'
     );
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/instance/999',
-      'get-item-details'
+      'get-item-details',
+      'test-token'
     );
     
     const responseData = JSON.parse(result.content[0].text);
@@ -281,6 +295,22 @@ describe('get-item-details tool', () => {
       expect(responseData).toEqual(mockSuccessfulItemResponse.result);
       expect(responseData.occurrence).toBeUndefined();
     });
+  });
+
+  it('should resolve project when project param is explicitly default', async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
+
+    const result = await toolHandler({ counter: 42, project: 'default' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/item_by_counter/42',
+      'get-item-details',
+      'test-token'
+    );
+    const responseData = JSON.parse(result.content[0].text);
+    expect(responseData).toHaveProperty('counter', 42);
   });
 
   it('should validate max_tokens parameter with Zod schema', () => {

--- a/tests/unit/tools/get-replay.test.ts
+++ b/tests/unit/tools/get-replay.test.ts
@@ -214,4 +214,86 @@ describe('get-replay tool', () => {
       'test-token'
     );
   });
+
+  it('should reject delivery=resource when multiple projects are configured', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      PROJECTS: [
+        { name: 'backend', token: 'token-1', apiBase: 'https://api.rollbar.com/api/1' },
+        { name: 'frontend', token: 'token-2', apiBase: 'https://api.rollbar.com/api/1' },
+      ],
+      resolveProject: vi.fn(() => ({
+        name: 'backend',
+        token: 'token-1',
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
+    }));
+
+    const { makeRollbarRequest } = await import('../../../src/utils/api.js');
+    const localMakeRollbarRequestMock = makeRollbarRequest as any;
+    localMakeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulReplayResponse);
+
+    const { registerGetReplayTool: register } = await import('../../../src/tools/get-replay.js');
+    let localToolHandler: any;
+    const localServer = {
+      tool: vi.fn((_name, _description, _schema, handler) => {
+        localToolHandler = handler;
+      }),
+    } as any;
+
+    register(localServer);
+
+    await expect(
+      localToolHandler({
+        environment: 'production',
+        sessionId: 'session-123',
+        replayId: 'replay-456',
+        project: 'backend',
+        delivery: 'resource',
+      })
+    ).rejects.toThrow(
+      'delivery="resource" is not supported when multiple projects are configured'
+    );
+  });
+
+  it('should still allow delivery=file when multiple projects are configured', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      PROJECTS: [
+        { name: 'backend', token: 'token-1', apiBase: 'https://api.rollbar.com/api/1' },
+        { name: 'frontend', token: 'token-2', apiBase: 'https://api.rollbar.com/api/1' },
+      ],
+      resolveProject: vi.fn(() => ({
+        name: 'backend',
+        token: 'token-1',
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
+    }));
+
+    const { makeRollbarRequest } = await import('../../../src/utils/api.js');
+    const localMakeRollbarRequestMock = makeRollbarRequest as any;
+    localMakeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulReplayResponse);
+
+    const { registerGetReplayTool: register } = await import('../../../src/tools/get-replay.js');
+    let localToolHandler: any;
+    const localServer = {
+      tool: vi.fn((_name, _description, _schema, handler) => {
+        localToolHandler = handler;
+      }),
+    } as any;
+
+    register(localServer);
+
+    await localToolHandler({
+      environment: 'production',
+      sessionId: 'session-123',
+      replayId: 'replay-456',
+      project: 'backend',
+      delivery: 'file',
+    });
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/tools/get-replay.test.ts
+++ b/tests/unit/tools/get-replay.test.ts
@@ -18,8 +18,19 @@ vi.mock('node:fs/promises', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 describe('get-replay tool', () => {
@@ -70,7 +81,8 @@ describe('get-replay tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/environment/production/session/session-123/replay/replay-456',
-      'get-replay'
+      'get-replay',
+      'test-token'
     );
 
     const expectedResourceUri = buildReplayResourceUri(
@@ -144,7 +156,8 @@ describe('get-replay tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/environment/prod%20env/session/session%2F123/replay/replay%3A456',
-      'get-replay'
+      'get-replay',
+      'test-token'
     );
   });
 
@@ -182,5 +195,23 @@ describe('get-replay tool', () => {
     expect(() => schema.sessionId.parse('')).toThrow();
     expect(() => schema.replayId.parse('replay-123')).not.toThrow();
     expect(() => schema.replayId.parse('')).toThrow();
+    expect(schema.project).toBeDefined();
+  });
+
+  it('should work with explicit project default', async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulReplayResponse);
+
+    await toolHandler({
+      environment: 'production',
+      sessionId: 'session-123',
+      replayId: 'replay-456',
+      project: 'default',
+    });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/environment/production/session/session-123/replay/replay-456',
+      'get-replay',
+      'test-token'
+    );
   });
 });

--- a/tests/unit/tools/get-top-items.test.ts
+++ b/tests/unit/tools/get-top-items.test.ts
@@ -8,8 +8,19 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 describe('get-top-items tool', () => {
@@ -40,7 +51,8 @@ describe('get-top-items tool', () => {
       'get-top-items',
       'Get list of top items in the Rollbar project',
       expect.objectContaining({
-        environment: expect.any(Object)
+        environment: expect.any(Object),
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -53,7 +65,8 @@ describe('get-top-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=staging&sort=occurrences',
-      'get-top-items'
+      'get-top-items',
+      'test-token'
     );
     expect(result.content[0].type).toBe('text');
     const parsed = JSON.parse(result.content[0].text);
@@ -68,7 +81,8 @@ describe('get-top-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=production&sort=occurrences',
-      'get-top-items'
+      'get-top-items',
+      'test-token'
     );
   });
 
@@ -133,7 +147,20 @@ describe('get-top-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=development&sort=occurrences',
-      'get-top-items'
+      'get-top-items',
+      'test-token'
+    );
+  });
+
+  it('should work with explicit project default', async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulTopItemsResponse);
+
+    await toolHandler({ environment: 'production', project: 'default' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=production&sort=occurrences',
+      'get-top-items',
+      'test-token'
     );
   });
 });

--- a/tests/unit/tools/get-version.test.ts
+++ b/tests/unit/tools/get-version.test.ts
@@ -8,8 +8,19 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 describe('get-version tool', () => {
@@ -41,7 +52,8 @@ describe('get-version tool', () => {
       'Get version details for a Rollbar project',
       expect.objectContaining({
         version: expect.any(Object),
-        environment: expect.any(Object)
+        environment: expect.any(Object),
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -54,7 +66,8 @@ describe('get-version tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/versions/v1.2.3?environment=staging',
-      'get-version'
+      'get-version',
+      'test-token'
     );
     expect(result.content[0].type).toBe('text');
     const parsed = JSON.parse(result.content[0].text);
@@ -69,7 +82,8 @@ describe('get-version tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/versions/abc123?environment=production',
-      'get-version'
+      'get-version',
+      'test-token'
     );
   });
 
@@ -145,7 +159,24 @@ describe('get-version tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/versions/git-sha-abc123?environment=development',
-      'get-version'
+      'get-version',
+      'test-token'
+    );
+  });
+
+  it('should work with explicit project default', async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulVersionResponse);
+
+    await toolHandler({
+      version: 'v1',
+      environment: 'production',
+      project: 'default',
+    });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/versions/v1?environment=production',
+      'get-version',
+      'test-token'
     );
   });
 });

--- a/tests/unit/tools/list-items.test.ts
+++ b/tests/unit/tools/list-items.test.ts
@@ -8,8 +8,19 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 describe('list-items tool', () => {
@@ -44,7 +55,8 @@ describe('list-items tool', () => {
         level: expect.any(Object),
         environment: expect.any(Object),
         page: expect.any(Object),
-        query: expect.any(Object)
+        query: expect.any(Object),
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -57,7 +69,8 @@ describe('list-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/items/?status=active&environment=production',
-      'list-items'
+      'list-items',
+      'test-token'
     );
 
     const responseData = JSON.parse(result.content[0].text);
@@ -88,7 +101,8 @@ describe('list-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/items/?status=resolved&level=error&level=critical&environment=staging&page=2&q=TypeError',
-      'list-items'
+      'list-items',
+      'test-token'
     );
 
     const responseData = JSON.parse(result.content[0].text);
@@ -107,7 +121,20 @@ describe('list-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/items/?status=active&environment=production',
-      'list-items'
+      'list-items',
+      'test-token'
+    );
+  });
+
+  it('should work with explicit project default', async () => {
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulListItemsResponse);
+
+    await toolHandler({ status: 'active', environment: 'production', project: 'default' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/items/?status=active&environment=production',
+      'list-items',
+      'test-token'
     );
   });
 
@@ -196,7 +223,8 @@ describe('list-items tool', () => {
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/items/?status=active&environment=production',
-      'list-items'
+      'list-items',
+      'test-token'
     );
   });
 

--- a/tests/unit/tools/list-projects.test.ts
+++ b/tests/unit/tools/list-projects.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerListProjectsTool } from '../../../src/tools/list-projects.js';
+
+vi.mock('../../../src/config.js', () => ({
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+}));
+
+describe('list-projects tool', () => {
+  let server: McpServer;
+  let toolHandler: (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }>;
+
+  beforeEach(async () => {
+    server = {
+      tool: vi.fn((_name, _description, _schema, handler) => {
+        toolHandler = handler as typeof toolHandler;
+      }),
+    } as any;
+    registerListProjectsTool(server);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should register the tool with name list-projects', () => {
+    expect(server.tool).toHaveBeenCalledWith(
+      'list-projects',
+      'List configured Rollbar projects available to this MCP server',
+      {},
+      expect.any(Function)
+    );
+  });
+
+  it('should return project names and apiBase but NOT tokens', async () => {
+    const result = await toolHandler({});
+    const content = JSON.parse(result.content[0].text) as Array<{
+      name: string;
+      apiBase: string;
+      token?: string;
+    }>;
+
+    expect(content).toHaveLength(1);
+    expect(content[0]).toEqual({
+      name: 'default',
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    expect(content[0]).not.toHaveProperty('token');
+  });
+
+  it('should return text content type', async () => {
+    const result = await toolHandler({});
+    expect(result.content[0].type).toBe('text');
+    expect(() => JSON.parse(result.content[0].text)).not.toThrow();
+  });
+});

--- a/tests/unit/tools/update-item.test.ts
+++ b/tests/unit/tools/update-item.test.ts
@@ -8,8 +8,19 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
-  ROLLBAR_API_BASE: 'https://api.rollbar.com/api/1',
-  ROLLBAR_ACCESS_TOKEN: 'test-token'
+  PROJECTS: [
+    {
+      name: 'default',
+      token: 'test-token',
+      apiBase: 'https://api.rollbar.com/api/1',
+    },
+  ],
+  resolveProject: vi.fn(() => ({
+    name: 'default',
+    token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
 describe('update-item tool', () => {
@@ -47,7 +58,8 @@ describe('update-item tool', () => {
         assignedUserId: expect.any(Object),
         resolvedInVersion: expect.any(Object),
         snoozed: expect.any(Object),
-        teamId: expect.any(Object)
+        teamId: expect.any(Object),
+        project: expect.any(Object),
       }),
       expect.any(Function)
     );
@@ -68,6 +80,7 @@ describe('update-item tool', () => {
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/item/123',
       'update-item',
+      'test-token',
       {
         method: 'PATCH',
         headers: {
@@ -102,6 +115,7 @@ describe('update-item tool', () => {
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/item/456',
       'update-item',
+      'test-token',
       {
         method: 'PATCH',
         headers: {
@@ -179,6 +193,7 @@ describe('update-item tool', () => {
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/item/123',
       'update-item',
+      'test-token',
       {
         method: 'PATCH',
         headers: {
@@ -186,6 +201,27 @@ describe('update-item tool', () => {
         },
         body: JSON.stringify({ title: 'New title' })
       }
+    );
+  });
+
+  it('should work with explicit project default', async () => {
+    const mockResponse = {
+      err: 0,
+      result: { id: 123, status: 'resolved' }
+    };
+    makeRollbarRequestMock.mockResolvedValueOnce(mockResponse);
+
+    await toolHandler({
+      itemId: 123,
+      status: 'resolved',
+      project: 'default',
+    });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/item/123',
+      'update-item',
+      'test-token',
+      expect.any(Object)
     );
   });
 
@@ -258,6 +294,7 @@ describe('update-item tool', () => {
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
       'https://api.rollbar.com/api/1/item/123',
       'update-item',
+      'test-token',
       {
         method: 'PATCH',
         headers: {

--- a/tests/unit/utils/api.test.ts
+++ b/tests/unit/utils/api.test.ts
@@ -13,7 +13,6 @@ describe('api utilities', () => {
     
     // Mock config module with test values
     vi.doMock('../../../src/config.js', () => ({
-      ROLLBAR_ACCESS_TOKEN: 'test-token',
       getUserAgent: (toolName: string) => `test-user-agent (tool: ${toolName})`
     }));
     
@@ -36,7 +35,7 @@ describe('api utilities', () => {
         json: vi.fn().mockResolvedValueOnce(mockResponse)
       });
 
-      const result = await makeRollbarRequest(testUrl, 'test-tool');
+      const result = await makeRollbarRequest(testUrl, 'test-tool', 'test-token');
 
       expect(fetchMock).toHaveBeenCalledWith(testUrl, {
         headers: {
@@ -48,18 +47,6 @@ describe('api utilities', () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it('should handle missing ROLLBAR_ACCESS_TOKEN', async () => {
-      vi.resetModules();
-      vi.doMock('../../../src/config.js', () => ({
-        ROLLBAR_ACCESS_TOKEN: undefined,
-        getUserAgent: (toolName: string) => `test-user-agent (tool: ${toolName})`
-      }));
-
-      const { makeRollbarRequest: makeRequest } = await import('../../../src/utils/api.js');
-      
-      await expect(makeRequest(testUrl, 'test-tool')).rejects.toThrow('ROLLBAR_ACCESS_TOKEN environment variable is not set');
-    });
-
     it('should handle HTTP 401 error response', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: false,
@@ -68,7 +55,7 @@ describe('api utilities', () => {
         text: vi.fn().mockResolvedValueOnce('')
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Rollbar API error: 401 Unauthorized');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Rollbar API error: 401 Unauthorized');
     });
 
     it('should handle HTTP 403 error response', async () => {
@@ -79,7 +66,7 @@ describe('api utilities', () => {
         text: vi.fn().mockResolvedValueOnce('')
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Rollbar API error: 403 Forbidden');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Rollbar API error: 403 Forbidden');
     });
 
     it('should handle HTTP 404 error response', async () => {
@@ -90,7 +77,7 @@ describe('api utilities', () => {
         text: vi.fn().mockResolvedValueOnce('')
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Rollbar API error: 404 Not Found');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Rollbar API error: 404 Not Found');
     });
 
     it('should handle HTTP 500 error response', async () => {
@@ -101,13 +88,13 @@ describe('api utilities', () => {
         text: vi.fn().mockResolvedValueOnce('')
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Rollbar API error: 500 Internal Server Error');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Rollbar API error: 500 Internal Server Error');
     });
 
     it('should handle network failure', async () => {
       fetchMock.mockRejectedValueOnce(new Error('Network error'));
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Network error');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Network error');
     });
 
     it('should handle JSON parsing errors', async () => {
@@ -116,7 +103,7 @@ describe('api utilities', () => {
         json: vi.fn().mockRejectedValueOnce(new Error('Invalid JSON'))
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Invalid JSON');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Invalid JSON');
     });
 
     it('should properly type the response', async () => {
@@ -131,7 +118,7 @@ describe('api utilities', () => {
         json: vi.fn().mockResolvedValueOnce(mockResponse)
       });
 
-      const result = await makeRollbarRequest<TestResponse>(testUrl, 'test-tool');
+      const result = await makeRollbarRequest<TestResponse>(testUrl, 'test-tool', 'test-token');
 
       expect(result).toEqual(mockResponse);
       expect(result?.id).toBe(1);
@@ -146,7 +133,7 @@ describe('api utilities', () => {
         text: vi.fn().mockResolvedValueOnce('{"message": "Custom error message"}')
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Rollbar API error: Custom error message');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Rollbar API error: Custom error message');
     });
 
     it('should include short text in error when not JSON', async () => {
@@ -157,7 +144,7 @@ describe('api utilities', () => {
         text: vi.fn().mockResolvedValueOnce('Short error text')
       });
 
-      await expect(makeRollbarRequest(testUrl, 'test-tool')).rejects.toThrow('Rollbar API error: 400 Bad Request - Short error text');
+      await expect(makeRollbarRequest(testUrl, 'test-tool', 'test-token')).rejects.toThrow('Rollbar API error: 400 Bad Request - Short error text');
     });
     it('should include tool name in user agent string', async () => {
       const mockResponse = { data: 'test' };
@@ -166,7 +153,7 @@ describe('api utilities', () => {
         json: vi.fn().mockResolvedValueOnce(mockResponse)
       });
 
-      await makeRollbarRequest(testUrl, 'get-item-details');
+      await makeRollbarRequest(testUrl, 'get-item-details', 'test-token');
 
       expect(fetchMock).toHaveBeenCalledWith(testUrl, {
         headers: {
@@ -184,7 +171,7 @@ describe('api utilities', () => {
         json: vi.fn().mockResolvedValue(mockResponse)
       });
 
-      await makeRollbarRequest(testUrl, 'list-items');
+      await makeRollbarRequest(testUrl, 'list-items', 'test-token');
       expect(fetchMock).toHaveBeenLastCalledWith(testUrl, {
         headers: {
           'User-Agent': 'test-user-agent (tool: list-items)',
@@ -193,7 +180,7 @@ describe('api utilities', () => {
         }
       });
 
-      await makeRollbarRequest(testUrl, 'update-item');
+      await makeRollbarRequest(testUrl, 'update-item', 'test-token');
       expect(fetchMock).toHaveBeenLastCalledWith(testUrl, {
         headers: {
           'User-Agent': 'test-user-agent (tool: update-item)',


### PR DESCRIPTION
### Summary

- Users with multiple Rollbar projects previously had to install and run a separate MCP server instance for each project. This PR allows a single MCP server instance to be configured with multiple projects, each with its own access token and optional API base URL.
- Adds a `.rollbar-mcp.json` config file format supporting named projects. Config is resolved from a 4-source lookup chain (explicit env var path → cwd → home dir → existing `ROLLBAR_ACCESS_TOKEN` env var), so all existing single-project setups continue to work with zero changes.
- Adds a `project` parameter to all tools so the LLM can specify which project to target when multiple are configured. The parameter is optional when only one project is configured.
- Adds a new `list-projects` tool so the LLM can discover which projects are available without the user having to explain it.