### PR TITLE
Disable e2e test requiring an externally managed Rollbar project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,3 @@ jobs:
 
     - name: Run end-to-end tests
       run: npm run test:e2e
-      env:
-        ROLLBAR_E2E_READ_TOKEN: ${{ secrets.ROLLBAR_E2E_READ_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,22 +6,30 @@ Contributions are welcome.
 
 Install and build:
 
-```
+```bash
 npm install
 npm run build
 ```
 
-Run your local installation from Claude Code:
+You can run the server directly to confirm it starts (it will wait for stdin; Ctrl+C to stop):
 
+```bash
+node build/index.js
 ```
+
+For local development, configure Rollbar either with an environment variable or a config file. Create `.rollbar-mcp.json` in the project root (or set `ROLLBAR_CONFIG_FILE` to its path) for single- or multi-project config—see the README Configuration section.
+
+### Run your local installation from Claude Code
+
+In your Claude Code MCP config (e.g. `.mcp.json`):
+
+```json
 {
   "mcpServers": {
     "rollbar": {
       "type": "stdio",
       "command": "node",
-      "args": [
-        "/ABSOLUTE/PATH/TO/rollbar-mcp-server/build/index.js"
-      ],
+      "args": ["/ABSOLUTE/PATH/TO/rollbar-mcp-server/build/index.js"],
       "env": {
         "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
       }
@@ -30,19 +38,42 @@ Run your local installation from Claude Code:
 }
 ```
 
-Add `ROLLBAR_API_BASE` to the `env` map if you need to point the server at a custom Rollbar API endpoint (for example, `"ROLLBAR_API_BASE": "https://rollbar-dev.example.com/api/1"`).
+To use a config file instead, set `"ROLLBAR_CONFIG_FILE": "/path/to/.rollbar-mcp.json"` in `env` (or omit it if `.rollbar-mcp.json` is in the project root or your home directory). Add `ROLLBAR_API_BASE` to `env` if you need a custom Rollbar API endpoint (e.g. `"ROLLBAR_API_BASE": "https://rollbar-dev.example.com/api/1"`).
 
-Run your local installation from VSCode:
+### Run your local installation from your IDE
 
+1. Open **Cursor Settings** (Cmd+, or File → Preferences).
+2. Go to **Cursor Settings → Features → MCP** (or search for “MCP”).
+3. Edit the MCP config and add a server that runs your local build:
+
+```json
+{
+  "mcpServers": {
+    "rollbar": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/ABSOLUTE/PATH/TO/rollbar-mcp-server/build/index.js"],
+      "env": {
+        "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
+      }
+    }
+  }
+}
 ```
+
+Replace `/ABSOLUTE/PATH/TO/rollbar-mcp-server` with the real path to your clone. To use a config file instead, set `"ROLLBAR_CONFIG_FILE": "/path/to/.rollbar-mcp.json"` in `env`. Save and restart Cursor (or reload the window) so the new server is picked up. In a new Agent/Composer chat, the Rollbar tools (e.g. `list-projects`, `get-item-details`) will be available.
+
+### Run your local installation from VS Code
+
+In your `.vscode/mcp.json`:
+
+```json
 {
   "servers": {
     "rollbar": {
       "type": "stdio",
       "command": "node",
-      "args": [
-        "/ABSOLUTE/PATH/TO/rollbar-mcp-server/build/index.js"
-      ],
+      "args": ["/ABSOLUTE/PATH/TO/rollbar-mcp-server/build/index.js"],
       "env": {
         "ROLLBAR_ACCESS_TOKEN": "<project read/write access token>"
       }
@@ -51,10 +82,23 @@ Run your local installation from VSCode:
 }
 ```
 
-You can test an individual tool using the `@modelcontextprotocol/inspector` module. For example, test the tool `get-item-details` with arg `counter=2455389`:
+You can use `ROLLBAR_CONFIG_FILE` in `env` instead of `ROLLBAR_ACCESS_TOKEN` for config-file-based setup.
 
+## Testing
+
+Test an individual tool with the MCP inspector. List tools:
+
+```bash
+npx @modelcontextprotocol/inspector --cli -e ROLLBAR_ACCESS_TOKEN=$TOKEN node build/index.js --method tools/list --debug
 ```
+
+Call a tool (e.g. `list-projects` or `get-item-details`):
+
+```bash
+npx @modelcontextprotocol/inspector --cli -e ROLLBAR_ACCESS_TOKEN=$TOKEN node build/index.js --method tools/call --tool-name list-projects --debug
 npx @modelcontextprotocol/inspector --cli -e ROLLBAR_ACCESS_TOKEN=$TOKEN node build/index.js --method tools/call --tool-name get-item-details --tool-arg counter=2455389 --debug
 ```
 
-To run the e2e tests, you'll need a read token in the env var ROLLBAR_E2E_READ_TOKEN, which should be a read-scope project access token for a Rollbar project that has items inside, including an item with counter #8.
+Replace `$TOKEN` with your Rollbar access token (or use a config file and set `ROLLBAR_CONFIG_FILE` in the env).
+
+The full e2e suite (`npm run test:e2e`) runs two scripts: the npx-install test (no token needed) and the get-item-details test. If `ROLLBAR_E2E_READ_TOKEN` is not set, the get-item-details test is skipped and the suite still passes. To run that test, set `ROLLBAR_E2E_READ_TOKEN` to a read-scope project access token for a Rollbar project that has items, including an item with counter #8.

--- a/tests/e2e/test-get-item-details.sh
+++ b/tests/e2e/test-get-item-details.sh
@@ -23,10 +23,11 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
-# Check if ROLLBAR_E2E_READ_TOKEN is set
+# Check if ROLLBAR_E2E_READ_TOKEN is set; skip this test if not (e.g. in CI without secrets)
 if [ -z "$ROLLBAR_E2E_READ_TOKEN" ]; then
-    echo -e "${RED}✗ ROLLBAR_E2E_READ_TOKEN environment variable is required${NC}"
-    exit 1
+    echo -e "${YELLOW}⊘ Skipping get-item-details e2e test (ROLLBAR_E2E_READ_TOKEN not set)${NC}"
+    echo "  To run this test, set ROLLBAR_E2E_READ_TOKEN to a read-scope token for a project that has an item with counter #8."
+    exit 0
 fi
 
 # Clean up function
@@ -77,14 +78,21 @@ echo "Running: $INSPECTOR_BIN --cli -e ROLLBAR_ACCESS_TOKEN=\$ROLLBAR_E2E_READ_T
 # Check the output using jq
 HAS_CONTENT=$(jq -r 'has("content")' test-output.json 2>/dev/null || echo "false")
 IS_ERROR=$(jq -r '.isError // false' test-output.json 2>/dev/null || echo "true")
+ERROR_TEXT=$(jq -r '.content[0].text // ""' test-output.json 2>/dev/null || echo "")
 
 if [ "$HAS_CONTENT" = "true" ] && [ "$IS_ERROR" = "false" ]; then
     echo -e "${GREEN}✓ E2E test passed!${NC}"
     echo "get-item-details works correctly via npx"
     exit 0
-else
-    echo -e "${RED}✗ E2E test failed: Tool invocation returned an error${NC}"
-    echo "Response:"
-    cat test-output.json
-    exit 1
 fi
+
+# API returned an error: if it's "not found", the project may not have item #8 — skip instead of fail (CI-friendly)
+if [ "$IS_ERROR" = "true" ] && echo "$ERROR_TEXT" | grep -qi "not found"; then
+    echo -e "${YELLOW}⊘ Skipping: API returned 'not found' (project may not have an item with counter #8)${NC}"
+    exit 0
+fi
+
+echo -e "${RED}✗ E2E test failed: Tool invocation returned an error${NC}"
+echo "Response:"
+cat test-output.json
+exit 1


### PR DESCRIPTION
# Problem

The test `tests/e2e/test-get-item-details.sh` relies on a Rollbar project existing that contains a test item at a specific counter value. When that value falls out of data retention, the test breaks.

# Solution

For now, disable the test.