### PR TITLE
Fix: honor HTTPS_PROXY/HTTP_PROXY in proxy-only environments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "dotenv": "^17.2.1",
         "rollbar": "^3.0.0-alpha.6",
+        "undici": "^7.25.0",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -5869,6 +5870,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "dotenv": "^17.2.1",
     "rollbar": "^3.0.0-alpha.6",
+    "undici": "^7.25.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,13 +1,9 @@
-import dotenv from "dotenv";
+import "./load-env.js";
 import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
 import packageJson from "../package.json" with { type: "json" };
 import { z } from "zod";
-
-// Load environment variables from .env file
-// `quiet: true` to prevent logging to stdio which disrupts some mcp clients
-dotenv.config({ quiet: true } as Parameters<typeof dotenv.config>[0]);
 
 const DEFAULT_ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import "./load-env.js";
 import "./utils/proxy.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import "./utils/proxy.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { registerAllTools } from "./tools/index.js";

--- a/src/load-env.ts
+++ b/src/load-env.ts
@@ -1,0 +1,4 @@
+import dotenv from "dotenv";
+
+// Keep dotenv quiet so MCP stdio stays clean for clients.
+dotenv.config({ quiet: true } as Parameters<typeof dotenv.config>[0]);

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,11 @@
+import { ProxyAgent, setGlobalDispatcher } from "undici";
+
+const proxyUrl =
+  process.env.HTTPS_PROXY ||
+  process.env.HTTP_PROXY ||
+  process.env.https_proxy ||
+  process.env.http_proxy;
+
+if (proxyUrl) {
+  setGlobalDispatcher(new ProxyAgent(proxyUrl));
+}

--- a/tests/unit/utils/proxy.test.ts
+++ b/tests/unit/utils/proxy.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockSetGlobalDispatcher = vi.fn();
+const mockProxyAgentConstructor = vi.fn();
+
+vi.mock('undici', () => ({
+  setGlobalDispatcher: mockSetGlobalDispatcher,
+  ProxyAgent: mockProxyAgentConstructor,
+}));
+
+describe('proxy setup', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('sets global dispatcher when HTTPS_PROXY is set', async () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
+    await import('../../../src/utils/proxy.js');
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets global dispatcher when HTTP_PROXY is set', async () => {
+    process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+    await import('../../../src/utils/proxy.js');
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets global dispatcher when lowercase https_proxy is set', async () => {
+    process.env.https_proxy = 'http://proxy.example.com:8080';
+    await import('../../../src/utils/proxy.js');
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets global dispatcher when lowercase http_proxy is set', async () => {
+    process.env.http_proxy = 'http://proxy.example.com:8080';
+    await import('../../../src/utils/proxy.js');
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers HTTPS_PROXY over HTTP_PROXY', async () => {
+    process.env.HTTPS_PROXY = 'http://https-proxy.example.com:8080';
+    process.env.HTTP_PROXY = 'http://http-proxy.example.com:8080';
+    await import('../../../src/utils/proxy.js');
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://https-proxy.example.com:8080');
+  });
+
+  it('does not set global dispatcher when no proxy env vars are set', async () => {
+    delete process.env.HTTPS_PROXY;
+    delete process.env.HTTP_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.http_proxy;
+    await import('../../../src/utils/proxy.js');
+    expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/utils/proxy.test.ts
+++ b/tests/unit/utils/proxy.test.ts
@@ -1,15 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 const mockSetGlobalDispatcher = vi.fn();
 const mockProxyAgentConstructor = vi.fn();
 
-vi.mock('undici', () => ({
+vi.mock("undici", () => ({
   setGlobalDispatcher: mockSetGlobalDispatcher,
   ProxyAgent: mockProxyAgentConstructor,
 }));
 
-describe('proxy setup', () => {
+describe("proxy setup", () => {
   const originalEnv = process.env;
+  const originalCwd = process.cwd();
 
   beforeEach(() => {
     process.env = { ...originalEnv };
@@ -19,49 +23,89 @@ describe('proxy setup', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    process.chdir(originalCwd);
   });
 
-  it('sets global dispatcher when HTTPS_PROXY is set', async () => {
-    process.env.HTTPS_PROXY = 'http://proxy.example.com:8080';
-    await import('../../../src/utils/proxy.js');
-    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+  it("sets global dispatcher when HTTPS_PROXY is set", async () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:8080";
+    await import("../../../src/utils/proxy.js");
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith(
+      "http://proxy.example.com:8080",
+    );
     expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it('sets global dispatcher when HTTP_PROXY is set', async () => {
-    process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
-    await import('../../../src/utils/proxy.js');
-    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+  it("sets global dispatcher when HTTP_PROXY is set", async () => {
+    process.env.HTTP_PROXY = "http://proxy.example.com:8080";
+    await import("../../../src/utils/proxy.js");
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith(
+      "http://proxy.example.com:8080",
+    );
     expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it('sets global dispatcher when lowercase https_proxy is set', async () => {
-    process.env.https_proxy = 'http://proxy.example.com:8080';
-    await import('../../../src/utils/proxy.js');
-    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+  it("sets global dispatcher when lowercase https_proxy is set", async () => {
+    process.env.https_proxy = "http://proxy.example.com:8080";
+    await import("../../../src/utils/proxy.js");
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith(
+      "http://proxy.example.com:8080",
+    );
     expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it('sets global dispatcher when lowercase http_proxy is set', async () => {
-    process.env.http_proxy = 'http://proxy.example.com:8080';
-    await import('../../../src/utils/proxy.js');
-    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://proxy.example.com:8080');
+  it("sets global dispatcher when lowercase http_proxy is set", async () => {
+    process.env.http_proxy = "http://proxy.example.com:8080";
+    await import("../../../src/utils/proxy.js");
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith(
+      "http://proxy.example.com:8080",
+    );
     expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 
-  it('prefers HTTPS_PROXY over HTTP_PROXY', async () => {
-    process.env.HTTPS_PROXY = 'http://https-proxy.example.com:8080';
-    process.env.HTTP_PROXY = 'http://http-proxy.example.com:8080';
-    await import('../../../src/utils/proxy.js');
-    expect(mockProxyAgentConstructor).toHaveBeenCalledWith('http://https-proxy.example.com:8080');
+  it("prefers HTTPS_PROXY over HTTP_PROXY", async () => {
+    process.env.HTTPS_PROXY = "http://https-proxy.example.com:8080";
+    process.env.HTTP_PROXY = "http://http-proxy.example.com:8080";
+    await import("../../../src/utils/proxy.js");
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith(
+      "http://https-proxy.example.com:8080",
+    );
   });
 
-  it('does not set global dispatcher when no proxy env vars are set', async () => {
+  it("does not set global dispatcher when no proxy env vars are set", async () => {
     delete process.env.HTTPS_PROXY;
     delete process.env.HTTP_PROXY;
     delete process.env.https_proxy;
     delete process.env.http_proxy;
-    await import('../../../src/utils/proxy.js');
+    await import("../../../src/utils/proxy.js");
     expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("honors proxy values loaded from .env before proxy setup runs", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "rollbar-mcp-proxy-"));
+
+    writeFileSync(
+      path.join(tempDir, ".env"),
+      "ROLLBAR_ACCESS_TOKEN=test-token\nHTTPS_PROXY=http://proxy.example.com:8080\n",
+    );
+
+    process.chdir(tempDir);
+    process.env = {
+      ...originalEnv,
+      HOME: tempDir,
+    };
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    delete process.env.ROLLBAR_CONFIG_FILE;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.HTTP_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.http_proxy;
+
+    await import("../../../src/load-env.js");
+    await import("../../../src/utils/proxy.js");
+
+    expect(mockProxyAgentConstructor).toHaveBeenCalledWith(
+      "http://proxy.example.com:8080",
+    );
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes `EAI_AGAIN` DNS failures in proxy-only environments (corporate networks, containerized sandboxes, Claude Code remote) where Node.js `fetch` (undici) silently ignores `HTTPS_PROXY`/`HTTP_PROXY` env vars
- Adds `undici` as an explicit dependency and installs a `ProxyAgent` as the global fetch dispatcher at startup when any proxy env var is detected (`HTTPS_PROXY`, `HTTP_PROXY`, `https_proxy`, `http_proxy`)
- No behavior change for users without a proxy configured

Closes #83

## How it works

A new `src/utils/proxy.ts` module is imported at the top of `src/index.ts` (before any `fetch()` calls). If a proxy env var is present, it calls `setGlobalDispatcher(new ProxyAgent(url))`, which makes all subsequent `fetch()` calls route through the proxy automatically.

`undici` is added as an explicit npm dependency for Node 20 compatibility — `node:undici` is only available from Node 22+, and the project targets `>=20`.

## Test plan

- [x] 6 unit tests added in `tests/unit/utils/proxy.test.ts` covering all four proxy env vars, priority ordering, and the no-proxy case
- [x] Smoke test: `HTTPS_PROXY=http://localhost:9999 node build/index.js` produces `ECONNREFUSED` (proxy attempted) rather than `EAI_AGAIN` (DNS failure) — confirming proxy routing is active
- [x] Full replication: run inside a Docker container with `--dns=0.0.0.0` (DNS blocked) and a real proxy on the host — traffic routes through the proxy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)