### PR TITLE
Add .npmrc ignore-scripts=true (Miasma install-hook mitigation)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Description of the change

Adds a repo-local `.npmrc` containing `ignore-scripts=true` so npm does not auto-execute dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) on `npm install`. This blocks the execution mechanism used by the Miasma / Shai-Hulud npm supply-chain worm.

Config-only change (maintenance). Explicit `npm run <script>` invocations are unaffected; only automatic install-time lifecycle scripts are suppressed. Part of a fleet-wide rollout tracked in Linear **PLA-1580** (one PR per repo).

## Type of change

> Maintenance / config — none of the bug-fix / feature / breaking categories apply.

## Related issues

- PLA-1580 (Linear): https://linear.app/rollbar-inc/issue/PLA-1580

## Checklists

### Development

- [x] N/A — configuration-only change, no code or tests affected

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
