### PR TITLE
Fix list-items ignoring the query parameter

### DIFF
--- a/src/tools/list-items.ts
+++ b/src/tools/list-items.ts
@@ -96,7 +96,7 @@ export function registerListItemsTool(server: McpServer) {
       }
 
       if (query) {
-        params.append("q", query);
+        params.append("query", query);
       }
 
       const listUrl = `${apiBase}/items/?${params.toString()}`;

--- a/tests/unit/tools/list-items.test.ts
+++ b/tests/unit/tools/list-items.test.ts
@@ -100,7 +100,7 @@ describe('list-items tool', () => {
     });
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
-      'https://api.rollbar.com/api/1/items/?status=resolved&level=error&level=critical&environment=staging&page=2&q=TypeError',
+      'https://api.rollbar.com/api/1/items/?status=resolved&level=error&level=critical&environment=staging&page=2&query=TypeError',
       'list-items',
       'test-token'
     );


### PR DESCRIPTION
Fixes #84

## Problem

The `list-items` tool's `query` argument had no effect — searches returned the full unfiltered item list, with `total_count` unchanged, regardless of the search term.

## Cause

The handler sent the free-text search term to Rollbar as `q`, but the `GET /api/1/items/` endpoint expects the parameter named `query`. Rollbar silently ignores unknown query-string params, so the search term was dropped and the unfiltered list came back. (The value still showed up in the response's `filters_applied`, since that's echoed from the tool input — matching the symptom reported in #84.)

## Fix

- Rename the query-string param from `q` to `query` in `list-items.ts`.
- Update the `list-items` unit test, which had hardcoded the buggy `q=` URL and was effectively asserting the bug.

## Testing

`npm test` — 16 files / 172 tests passing.
Verified end-to-end via `npx github:…#fix/list-items-query-param`: `query` now filters results as expected.