### PR TITLE
Use GET /item?counter= instead of the deprecated item_by_counter endpoint

### DIFF
--- a/src/tools/get-item-details.ts
+++ b/src/tools/get-item-details.ts
@@ -28,8 +28,7 @@ export function registerGetItemDetailsTool(server: McpServer) {
     },
     async ({ counter, max_tokens, project }) => {
       const { token, apiBase } = resolveProject(project);
-      // Redirects are followed, so we get an item response from the counter request
-      const counterUrl = `${apiBase}/item_by_counter/${counter}`;
+      const counterUrl = `${apiBase}/item?counter=${counter}`;
       const itemResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarItemResponse>
       >(counterUrl, "get-item-details", token);

--- a/tests/unit/tools/get-item-details.test.ts
+++ b/tests/unit/tools/get-item-details.test.ts
@@ -86,7 +86,7 @@ describe('get-item-details tool', () => {
     const result = await toolHandler({ counter: 42, project: undefined });
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
-      'https://api.rollbar.com/api/1/item_by_counter/42',
+      'https://api.rollbar.com/api/1/item?counter=42',
       'get-item-details',
       'test-token'
     );
@@ -305,7 +305,7 @@ describe('get-item-details tool', () => {
     const result = await toolHandler({ counter: 42, project: 'default' });
 
     expect(makeRollbarRequestMock).toHaveBeenCalledWith(
-      'https://api.rollbar.com/api/1/item_by_counter/42',
+      'https://api.rollbar.com/api/1/item?counter=42',
       'get-item-details',
       'test-token'
     );


### PR DESCRIPTION
## What

Swaps get-item-details off `GET /item_by_counter/{counter}` onto `GET /item?counter=`. Same response shape (`{err, result}`), same follow-up `GET /instance/{last_occurrence_id}` call — nothing else in the tool changes.

## Why

The old endpoint is deprecated: it 301-redirects with a live access token embedded in the query string of the redirect URL, which is a wart we don't need to keep around. It also doesn't accept account access tokens, which makes it a hard blocker for the account-token support work landing next (Linear ROL-1014/ROL-1016). The replacement returns the identical payload with neither problem.

Verified directly against production (api.rollbar.com) on 2026-07-20/21.

## Testing

- `npm test` — 165/165 passing, including updated URL assertions in `tests/unit/tools/get-item-details.test.ts`
- `npm run lint` — clean
- `npm run build` — clean
- Grepped `src/` and `tests/` for `item_by_counter` — zero remaining references

Linear: ROL-1015