### PR TITLE
Add account access token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,65 @@ Config file lookup order:
 1. `ROLLBAR_CONFIG_FILE` env var
 2. `.rollbar-mcp.json` in current working directory
 3. `~/.rollbar-mcp.json` in home directory
-4. `ROLLBAR_ACCESS_TOKEN` env var (single project, backward compatible)
+4. `ROLLBAR_ACCESS_TOKEN` or `ROLLBAR_ACCOUNT_ACCESS_TOKEN` env var (single project or account-wide, backward compatible)
 
 If a config file exists but is invalid, the server exits with an error instead of falling back to a lower-priority config source.
 
+**Account access token (one token for every project)**
+
+Instead of maintaining and rotating a token per project, you can configure a single Rollbar **account** access token and let every tool work across all projects in that account:
+
+- `ROLLBAR_ACCOUNT_ACCESS_TOKEN` (env var), or
+- `accountToken` (a top-level key in `.rollbar-mcp.json`, alongside `projects`/`token`/`apiBase`)
+
+To create one: in Rollbar, go to your **account settings → Account Access Tokens**, create a new named, enabled token, and choose **read** (or **read and write**, if you plan to use `update-item`) scope. Copy the full generated secret right away — Rollbar only shows it once — and store it securely (a secrets manager or your shell's env config, not committed to source control).
+
+```json
+{
+  "accountToken": "acct_tok_abc123"
+}
+```
+
+or combined with explicit per-project tokens:
+
+```json
+{
+  "accountToken": "acct_tok_abc123",
+  "projects": [
+    { "name": "backend", "token": "tok_backend_readwrite" }
+  ]
+}
+```
+
+With an account token configured, every tool's `project` parameter accepts a real Rollbar project **name** (case-insensitive) or numeric **id**, resolved live against `GET /projects`. If the account has exactly one enabled project, it's used automatically when `project` is omitted; if there are multiple, you must specify one. `list-projects()` returns the real projects on the account (id, name, status) instead of the local config echo.
+
+Project-token configs are **completely unchanged** by this feature — if you don't set an account token, nothing about existing single- or multi-project setups behaves any differently. The two modes can also coexist: if a `project` name matches an explicitly configured project that has its own token, that project's own token is always used for that project, even when an account token is also present.
+
+Required scopes:
+
+- Read-only tools (`get-item-details`, `get-deployments`, `get-version`, `get-top-items`, `list-items`, `get-replay`, `list-projects`) work with a **read**-scope account token.
+- `update-item` requires an account token with **both read and write** scope — every account-token call resolves the target project via `GET /projects` first (read), then makes the `PATCH` request (write). A write-only token will fail at the project-resolution step before ever reaching the update.
+- As with project tokens, prefer a read-scope token unless you specifically need `update-item`.
+
+If the server detects only `ROLLBAR_ACCESS_TOKEN` is set (no explicit account token), it makes a one-time, cached check against `GET /projects` to see whether that token is actually an account token; if so, account mode activates automatically. A single project-scoped token continues to work exactly as before.
+
 ### Tools
 
-`list-projects()`: List configured Rollbar projects (names and apiBase only; tokens are never returned). Use this when multiple projects are configured to see which project names you can pass to other tools.
+`list-projects()`: List available Rollbar projects. In project-token mode, lists the locally configured projects (names and apiBase only; tokens are never returned). In account-token mode, lists the real projects on the account (id, name, status) fetched live from Rollbar.
 
-`get-item-details(counter, max_tokens?, project?)`: Given an item number, fetch the item details and last occurrence details. Supports an optional `max_tokens` parameter (default: 20000) to automatically truncate large occurrence responses. Optional `project` selects which configured project to use when multiple are defined. Example prompt: `Diagnose the root cause of Rollbar item #123456`
+`get-item-details(counter, max_tokens?, project?)`: Given an item number, fetch the item details and last occurrence details. Supports an optional `max_tokens` parameter (default: 20000) to automatically truncate large occurrence responses. Optional `project` selects which project to use (by configured name, or by real project name/id in account-token mode). Example prompt: `Diagnose the root cause of Rollbar item #123456`
 
-`get-deployments(limit, project?)`: List deploy data for the given project. Optional `project` when multiple projects are configured. Example prompt: `List the last 5 deployments` or `Are there any failed deployments?`
+`get-deployments(limit, project?)`: List deploy data for the given project. Optional `project` when multiple projects are configured or in account-token mode. Example prompt: `List the last 5 deployments` or `Are there any failed deployments?`
 
-`get-version(version, environment, project?)`: Fetch version details for the given version string and environment. Optional `project` when multiple projects are configured.
+`get-version(version, environment, project?)`: Fetch version details for the given version string and environment. Optional `project` when multiple projects are configured or in account-token mode.
 
-`get-top-items(environment, project?)`: Fetch the top items in the last 24 hours for the given environment. Optional `project` when multiple projects are configured.
+`get-top-items(environment, project?)`: Fetch the top items in the last 24 hours for the given environment. Optional `project` when multiple projects are configured or in account-token mode.
 
-`list-items(status?, level?, environment?, page?, limit?, query?, project?)`: List items filtered by status, environment, and search query. Optional `project` when multiple projects are configured.
+`list-items(status?, level?, environment?, page?, limit?, query?, project?)`: List items filtered by status, environment, and search query. Optional `project` when multiple projects are configured or in account-token mode.
 
-`get-replay(environment, sessionId, replayId, delivery?, project?)`: Retrieve session replay metadata and payload for a specific session. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Optional `project` when multiple projects are configured. `delivery="resource"` is only supported in single-project mode; when multiple projects are configured, use `delivery="file"` with a `project` parameter instead. Example prompt: `Fetch the replay 789 from session abc in staging`.
+`get-replay(environment, sessionId, replayId, delivery?, project?)`: Retrieve session replay metadata and payload for a specific session. By default the tool writes the replay JSON to a temporary file (under your system temp directory) and returns the path. Set `delivery="resource"` to receive a `rollbar://replay/<environment>/<sessionId>/<replayId>` link for MCP-aware clients. Optional `project` when multiple projects are configured or in account-token mode. `delivery="resource"` is only supported when the server addresses a single project (single-project-token mode, or account-token mode with exactly one project); otherwise use `delivery="file"` with a `project` parameter instead. Example prompt: `Fetch the replay 789 from session abc in staging`.
 
-`update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?, project?)`: Update an item's properties including status, level, title, assignment, and more. Optional `project` when multiple projects are configured. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. (Requires `write` scope)
+`update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?, project?)`: Update an item's properties including status, level, title, assignment, and more. Optional `project` when multiple projects are configured or in account-token mode. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. Requires a project token with `write` scope, or an account token with both `read` and `write` scope.
 
 ## How to Use
 
@@ -87,6 +125,23 @@ Using an environment variable (single project):
 ```
 
 Optionally include `ROLLBAR_API_BASE` in the `env` block to target a non-production API endpoint.
+
+Using an account access token (every project on the account, no per-project tokens needed):
+
+```json
+{
+  "mcpServers": {
+    "rollbar": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@rollbar/mcp-server@latest"],
+      "env": {
+        "ROLLBAR_ACCOUNT_ACCESS_TOKEN": "<account access token>"
+      }
+    }
+  }
+}
+```
 
 Using a config file (single or multiple projects):
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,44 @@ A Model Context Protocol (MCP) server for [Rollbar](https://rollbar.com).
 
 This MCP server implements the `stdio` server type, which means your AI tool (e.g. Claude, Cursor) will run it directly; you don't run a separate process or connect over http.
 
-### Configuration
+## Configuration
 
-**Single Project: Environment variable (single project, backward compatible)**
+### Account access token
+
+Configure a single Rollbar Account Access Token and let every tool work across all projects in that account:
+
+- `ROLLBAR_ACCOUNT_ACCESS_TOKEN` (env var), or
+- `accountToken` (a top-level key in `.rollbar-mcp.json`, alongside `projects`/`token`/`apiBase`)
+
+To create one: in Rollbar, go to your **account settings → Account Access Tokens**, create a new named, enabled token, and choose **read** (or **read and write**, if you plan to use `update-item`) scope. Copy the full generated secret right away, Rollbar only shows it once, and store it securely (a secrets manager or your shell's env config, not committed to source control).
+
+```json
+{
+  "accountToken": "acct_tok_abc123"
+}
+```
+
+If you want tighter controls on some projects, give the account token read scope so you can read every project, then explicitly list the few projects that need `update-item` with their own read+write project tokens. Those override the account token for that project only, per the precedence rule below (explicit project token always wins).
+
+```json
+{
+  "accountToken": "acct_tok_abc123",
+  "projects": [
+    { "name": "backend", "token": "tok_backend_readwrite" }
+  ]
+}
+```
+
+Project-token configs are completely unchanged by this feature: if you don't set an account token, nothing about existing single- or multi-project setups behaves any differently. The two modes can also coexist: if a `project` name matches an explicitly configured project that has its own token, that project's own token is always used for that project, even when an account token is also present.
+
+### Per-project configuration for more secure access
+
+**Single Project: Environment variable**
 
 - `ROLLBAR_ACCESS_TOKEN`: access token for your Rollbar project.
 - `ROLLBAR_API_BASE` (optional): override the API base URL (defaults to `https://api.rollbar.com/api/1`).
 
-**Multiple Project: Config file (single or multiple projects)**
+**Multiple Project: Config file**
 
 Create `.rollbar-mcp.json` in your working directory or home directory, or set `ROLLBAR_CONFIG_FILE` to point to a custom path. A checked-in template is available at `rollbar-mcp-example.json`; copy it to `.rollbar-mcp.json` and fill in your real tokens.
 
@@ -43,40 +73,10 @@ Config file lookup order:
 
 If a config file exists but is invalid, the server exits with an error instead of falling back to a lower-priority config source.
 
-**Account access token (one token for every project)**
-
-Instead of maintaining and rotating a token per project, you can configure a single Rollbar **account** access token and let every tool work across all projects in that account:
-
-- `ROLLBAR_ACCOUNT_ACCESS_TOKEN` (env var), or
-- `accountToken` (a top-level key in `.rollbar-mcp.json`, alongside `projects`/`token`/`apiBase`)
-
-To create one: in Rollbar, go to your **account settings → Account Access Tokens**, create a new named, enabled token, and choose **read** (or **read and write**, if you plan to use `update-item`) scope. Copy the full generated secret right away — Rollbar only shows it once — and store it securely (a secrets manager or your shell's env config, not committed to source control).
-
-```json
-{
-  "accountToken": "acct_tok_abc123"
-}
-```
-
-or combined with explicit per-project tokens:
-
-```json
-{
-  "accountToken": "acct_tok_abc123",
-  "projects": [
-    { "name": "backend", "token": "tok_backend_readwrite" }
-  ]
-}
-```
-
-With an account token configured, every tool's `project` parameter accepts a real Rollbar project **name** (case-insensitive) or numeric **id**, resolved live against `GET /projects`. If the account has exactly one enabled project, it's used automatically when `project` is omitted; if there are multiple, you must specify one. `list-projects()` returns the real projects on the account (id, name, status) instead of the local config echo.
-
-Project-token configs are **completely unchanged** by this feature — if you don't set an account token, nothing about existing single- or multi-project setups behaves any differently. The two modes can also coexist: if a `project` name matches an explicitly configured project that has its own token, that project's own token is always used for that project, even when an account token is also present.
-
 Required scopes:
 
 - Read-only tools (`get-item-details`, `get-deployments`, `get-version`, `get-top-items`, `list-items`, `get-replay`, `list-projects`) work with a **read**-scope account token.
-- `update-item` requires an account token with **both read and write** scope — every account-token call resolves the target project via `GET /projects` first (read), then makes the `PATCH` request (write). A write-only token will fail at the project-resolution step before ever reaching the update.
+- `update-item` requires an account token with **both read and write** scope: every account-token call resolves the target project via `GET /projects` first (read), then makes the `PATCH` request (write). A write-only token will fail at the project-resolution step before ever reaching the update.
 - As with project tokens, prefer a read-scope token unless you specifically need `update-item`.
 
 If the server detects only `ROLLBAR_ACCESS_TOKEN` is set (no explicit account token), it makes a one-time, cached check against `GET /projects` to see whether that token is actually an account token; if so, account mode activates automatically. A single project-scoped token continues to work exactly as before.
@@ -100,8 +100,6 @@ If the server detects only `ROLLBAR_ACCESS_TOKEN` is set (no explicit account to
 `update-item(itemId, status?, level?, title?, assignedUserId?, resolvedInVersion?, snoozed?, teamId?, project?)`: Update an item's properties including status, level, title, assignment, and more. Optional `project` when multiple projects are configured or in account-token mode. Example prompt: `Mark Rollbar item #123456 as resolved` or `Assign item #123456 to user ID 789`. Requires a project token with `write` scope, or an account token with both `read` and `write` scope.
 
 ## How to Use
-
-Tested with node 20 and 22 (`nvm use 22`).
 
 ### Claude Code
 
@@ -261,4 +259,4 @@ Configure your `.vscode/mcp.json` as follows (env var or `ROLLBAR_CONFIG_FILE` f
 }
 ```
 
-Or using a local development installation—see CONTRIBUTING.md.
+Or using a local development installation, see CONTRIBUTING.md.

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { homedir } from "node:os";
 import packageJson from "../package.json" with { type: "json" };
 import { z } from "zod";
+import { getProjects, resolveProjectId } from "./utils/projects-cache.js";
 
 const DEFAULT_ROLLBAR_API_BASE = "https://api.rollbar.com/api/1";
 
@@ -30,6 +31,7 @@ const RollbarMcpConfigSchema = z
   .object({
     projects: z.array(ProjectConfigSchema).min(1),
     apiBase: HttpUrlSchema.optional(),
+    accountToken: z.string().min(1).optional(),
   })
   .passthrough()
   .refine((value) => !("token" in value), {
@@ -41,15 +43,40 @@ const RollbarMcpConfigShorthandSchema = z
   .object({
     token: z.string().min(1),
     apiBase: HttpUrlSchema.optional(),
+    accountToken: z.string().min(1).optional(),
   })
   .passthrough()
   .refine((value) => !("projects" in value), {
     message: '"projects" is not allowed in single-project shorthand config.',
   });
 
+// Account-token-only config (no project-token entries at all): just
+// `{ "accountToken": "..." }`, optionally with `apiBase`. Neither the
+// multi-project nor the shorthand schema matches this shape since both
+// require a project token.
+const RollbarMcpConfigAccountOnlySchema = z
+  .object({
+    accountToken: z.string().min(1),
+    apiBase: HttpUrlSchema.optional(),
+  })
+  .passthrough()
+  .refine((value) => !("projects" in value) && !("token" in value), {
+    message:
+      '"projects"/"token" are not allowed in an account-token-only config.',
+  });
+
 export interface ProjectConfig {
   name: string;
   token: string;
+  apiBase: string;
+}
+
+export type AuthTokenType = "project" | "account";
+
+export interface AuthContext {
+  token: string;
+  tokenType: AuthTokenType;
+  projectId?: number;
   apiBase: string;
 }
 
@@ -80,7 +107,13 @@ function normalizeApiBase(value: string | undefined): string {
   return value.replace(/\/+$/, "");
 }
 
-function loadProjectsFromFile(filePath: string): ProjectConfig[] | null {
+interface LoadedFileConfig {
+  projects: ProjectConfig[];
+  accountToken?: string;
+  apiBase: string;
+}
+
+function loadProjectsFromFile(filePath: string): LoadedFileConfig | null {
   if (!existsSync(filePath)) {
     return null;
   }
@@ -99,27 +132,44 @@ function loadProjectsFromFile(filePath: string): ProjectConfig[] | null {
   const multi = RollbarMcpConfigSchema.safeParse(json);
   if (multi.success) {
     const sharedApiBase = normalizeApiBase(multi.data.apiBase);
-    return multi.data.projects.map((p) => ({
-      name: p.name,
-      token: p.token,
+    return {
+      projects: multi.data.projects.map((p) => ({
+        name: p.name,
+        token: p.token,
+        apiBase: sharedApiBase,
+      })),
+      accountToken: multi.data.accountToken,
       apiBase: sharedApiBase,
-    }));
+    };
   }
 
   const shorthand = RollbarMcpConfigShorthandSchema.safeParse(json);
   if (shorthand.success) {
     const apiBase = normalizeApiBase(shorthand.data.apiBase);
-    return [
-      {
-        name: "default",
-        token: shorthand.data.token,
-        apiBase,
-      },
-    ];
+    return {
+      projects: [
+        {
+          name: "default",
+          token: shorthand.data.token,
+          apiBase,
+        },
+      ],
+      accountToken: shorthand.data.accountToken,
+      apiBase,
+    };
+  }
+
+  const accountOnly = RollbarMcpConfigAccountOnlySchema.safeParse(json);
+  if (accountOnly.success) {
+    return {
+      projects: [],
+      accountToken: accountOnly.data.accountToken,
+      apiBase: normalizeApiBase(accountOnly.data.apiBase),
+    };
   }
 
   throw new Error(
-    `Invalid Rollbar config file "${filePath}": expected either a single-project config like { "token": "..." } or a multi-project config like { "projects": [...] }.`,
+    `Invalid Rollbar config file "${filePath}": expected an account-only config like { "accountToken": "..." }, a single-project config like { "token": "..." }, or a multi-project config like { "projects": [...] }.`,
   );
 }
 
@@ -129,7 +179,25 @@ function exitWithError(message: string): never {
   return undefined as never;
 }
 
-function loadConfig(): ProjectConfig[] {
+function resolveAccountTokenFromEnv(): string | undefined {
+  const envValue = process.env.ROLLBAR_ACCOUNT_ACCESS_TOKEN?.trim();
+  return envValue && envValue.length > 0 ? envValue : undefined;
+}
+
+interface ResolvedConfig {
+  projects: ProjectConfig[];
+  accountToken?: string;
+  apiBase: string;
+  // True only when the single project in `projects` came from the legacy
+  // ROLLBAR_ACCESS_TOKEN env var (loadConfig() step 4), as opposed to a
+  // single-project config file/shorthand config. Only that legacy path
+  // should ever trigger the lazy GET /projects probe — a single-project
+  // config file is unambiguously project-token-only and must never make an
+  // unsolicited network call.
+  isLegacyEnvToken?: boolean;
+}
+
+function loadConfig(): ResolvedConfig {
   // 1. ROLLBAR_CONFIG_FILE env var
   const configFileEnv = process.env.ROLLBAR_CONFIG_FILE?.trim();
   if (configFileEnv) {
@@ -137,9 +205,13 @@ function loadConfig(): ProjectConfig[] {
       ? configFileEnv
       : path.resolve(process.cwd(), configFileEnv);
     try {
-      const projects = loadProjectsFromFile(resolved);
-      if (projects) {
-        return projects;
+      const loaded = loadProjectsFromFile(resolved);
+      if (loaded) {
+        return {
+          projects: loaded.projects,
+          accountToken: loaded.accountToken ?? resolveAccountTokenFromEnv(),
+          apiBase: loaded.apiBase,
+        };
       }
     } catch (error) {
       return exitWithError(
@@ -155,7 +227,13 @@ function loadConfig(): ProjectConfig[] {
   const cwdPath = path.join(process.cwd(), ".rollbar-mcp.json");
   try {
     const fromCwd = loadProjectsFromFile(cwdPath);
-    if (fromCwd) return fromCwd;
+    if (fromCwd) {
+      return {
+        projects: fromCwd.projects,
+        accountToken: fromCwd.accountToken ?? resolveAccountTokenFromEnv(),
+        apiBase: fromCwd.apiBase,
+      };
+    }
   } catch (error) {
     return exitWithError(
       error instanceof Error ? error.message : "Invalid Rollbar config file",
@@ -166,43 +244,150 @@ function loadConfig(): ProjectConfig[] {
   const homePath = path.join(homedir(), ".rollbar-mcp.json");
   try {
     const fromHome = loadProjectsFromFile(homePath);
-    if (fromHome) return fromHome;
+    if (fromHome) {
+      return {
+        projects: fromHome.projects,
+        accountToken: fromHome.accountToken ?? resolveAccountTokenFromEnv(),
+        apiBase: fromHome.apiBase,
+      };
+    }
   } catch (error) {
     return exitWithError(
       error instanceof Error ? error.message : "Invalid Rollbar config file",
     );
   }
 
-  // 4. ROLLBAR_ACCESS_TOKEN env var — synthesize single project
+  // 4. ROLLBAR_ACCESS_TOKEN / ROLLBAR_ACCOUNT_ACCESS_TOKEN env vars
   const token = process.env.ROLLBAR_ACCESS_TOKEN?.trim();
-  if (token && token.length > 0) {
+  const accountToken = resolveAccountTokenFromEnv();
+
+  if ((token && token.length > 0) || accountToken) {
     const apiBase = resolveApiBaseFromEnv();
     if (apiBase === null) {
       return exitWithError(
         "Error: ROLLBAR_API_BASE must be a valid HTTP(S) URL when using ROLLBAR_ACCESS_TOKEN.",
       );
     }
-    return [
-      {
-        name: "default",
-        token,
-        apiBase,
-      },
-    ];
+
+    // If only an account token is present (no project token), synthesize an
+    // empty project list — resolveProject()'s account-mode path takes over.
+    const projects: ProjectConfig[] =
+      token && token.length > 0
+        ? [
+            {
+              name: "default",
+              token,
+              apiBase,
+            },
+          ]
+        : [];
+
+    return {
+      projects,
+      accountToken,
+      apiBase,
+      isLegacyEnvToken: token !== undefined && token.length > 0,
+    };
   }
 
   return exitWithError(
-    "Error: No Rollbar configuration found. Set ROLLBAR_ACCESS_TOKEN, or create .rollbar-mcp.json (in cwd or home), or set ROLLBAR_CONFIG_FILE.",
+    "Error: No Rollbar configuration found. Set ROLLBAR_ACCESS_TOKEN or ROLLBAR_ACCOUNT_ACCESS_TOKEN, or create .rollbar-mcp.json (in cwd or home), or set ROLLBAR_CONFIG_FILE.",
   );
 }
 
-export const PROJECTS: ProjectConfig[] = loadConfig();
+// exitWithError() calls process.exit(1), which in tests is mocked to be a
+// no-op so execution can fall through; guard with a safe default so that
+// case doesn't crash while process.exit is unwinding.
+const resolvedConfig: ResolvedConfig = loadConfig() ?? {
+  projects: [],
+  apiBase: DEFAULT_ROLLBAR_API_BASE,
+};
+
+export const PROJECTS: ProjectConfig[] = resolvedConfig.projects;
+
+const ACCOUNT_TOKEN: string | undefined = resolvedConfig.accountToken;
+
+// Whether an explicit account token (env var or config file key) is
+// configured. Used by buildProjectParam() to decide the `project` param's
+// schema — a hybrid config (explicit project tokens + an account token) must
+// not restrict `project` to just the explicitly-listed names, since the
+// account token can also reach any other project on the account.
+export const HAS_ACCOUNT_TOKEN: boolean = Boolean(ACCOUNT_TOKEN);
+
+const DEFAULT_API_BASE: string = resolvedConfig.apiBase;
+const IS_LEGACY_ENV_TOKEN: boolean = resolvedConfig.isLegacyEnvToken ?? false;
+
+// Lazy probe-fallback state for the legacy ROLLBAR_ACCESS_TOKEN-only path.
+// Determines, on first use, whether that single token is actually an
+// account token (masquerading as a project token) by calling GET /projects.
+// The result is cached for the process lifetime so we never probe twice.
+type ProbeResult = "account" | "project";
+let probePromise: Promise<ProbeResult> | undefined;
+
+async function probeTokenType(
+  token: string,
+  apiBase: string,
+): Promise<ProbeResult> {
+  try {
+    const response = await fetch(`${apiBase}/projects`, {
+      headers: {
+        "X-Rollbar-Access-Token": token,
+        Accept: "application/json",
+      },
+    });
+    if (response.ok) {
+      return "account";
+    }
+    return "project";
+  } catch (error) {
+    console.error(
+      `Warning: failed to probe Rollbar token type (${
+        error instanceof Error ? error.message : "unknown network error"
+      }). Falling back to project-token behavior.`,
+    );
+    return "project";
+  }
+}
+
+/**
+ * Resolves the single legacy-token project's auth context, lazily probing
+ * GET /projects the first time it's needed to determine whether that token
+ * is actually an account token. Only called when PROJECTS has exactly one
+ * entry AND that entry came from the legacy ROLLBAR_ACCESS_TOKEN env var
+ * (IS_LEGACY_ENV_TOKEN) — a single project from a config file/shorthand
+ * config is unambiguously project-token-only and must never reach here.
+ */
+async function resolveLegacyTokenContext(
+  legacyProject: ProjectConfig,
+): Promise<AuthContext> {
+  if (!probePromise) {
+    probePromise = probeTokenType(legacyProject.token, legacyProject.apiBase);
+  }
+  const result = await probePromise;
+  if (result === "account") {
+    return {
+      token: legacyProject.token,
+      tokenType: "account",
+      apiBase: legacyProject.apiBase,
+    };
+  }
+  return {
+    token: legacyProject.token,
+    tokenType: "project",
+    apiBase: legacyProject.apiBase,
+  };
+}
 
 export function resolveProject(name: string | undefined): ProjectConfig {
   if (PROJECTS.length === 1 && name === undefined) {
     return PROJECTS[0];
   }
   if (name === undefined) {
+    if (PROJECTS.length === 0) {
+      throw new Error(
+        "No project-token projects configured. This server is running in account-token mode; use resolveAuthContext() instead of resolveProject().",
+      );
+    }
     throw new Error(
       `Multiple projects configured. Specify a project name. Available: ${PROJECTS.map((p) => p.name).join(", ")}`,
     );
@@ -214,6 +399,141 @@ export function resolveProject(name: string | undefined): ProjectConfig {
     );
   }
   return found;
+}
+
+/**
+ * Resolves the auth context (token + tokenType + resolved projectId) for a
+ * given `project` request parameter. This is the account-token-aware
+ * counterpart to resolveProject(): callers that want project_id injection
+ * support should use this instead.
+ *
+ * Precedence:
+ *   a. An explicitly configured project with its own token, matching by
+ *      name — unchanged from today's project-token behavior. Always wins.
+ *   b. An account token (config `accountToken` or ROLLBAR_ACCOUNT_ACCESS_TOKEN)
+ *      — resolves `project` (name or numeric id) against the projects cache.
+ *   c. The legacy ROLLBAR_ACCESS_TOKEN-only path — lazily probes GET /projects
+ *      once to determine whether it's actually an account token.
+ */
+export async function resolveAuthContext(
+  project: string | undefined,
+): Promise<AuthContext> {
+  // (a) Explicit project-token config always wins for a named project.
+  if (project !== undefined) {
+    const explicit = PROJECTS.find((p) => p.name === project);
+    if (explicit) {
+      return {
+        token: explicit.token,
+        tokenType: "project",
+        apiBase: explicit.apiBase,
+      };
+    }
+  }
+
+  // (b) Explicit account token present (env or config file key).
+  if (ACCOUNT_TOKEN) {
+    const projectId = await resolveProjectId(
+      ACCOUNT_TOKEN,
+      DEFAULT_API_BASE,
+      project,
+    );
+    return {
+      token: ACCOUNT_TOKEN,
+      tokenType: "account",
+      projectId,
+      apiBase: DEFAULT_API_BASE,
+    };
+  }
+
+  // (c) Legacy single ROLLBAR_ACCESS_TOKEN path — lazy probe fallback. Only
+  // applies when the single project actually came from that env var; a
+  // single-project config file/shorthand config is unambiguously
+  // project-token-only and must never trigger the probe's network call.
+  if (PROJECTS.length === 1 && IS_LEGACY_ENV_TOKEN) {
+    const legacyContext = await resolveLegacyTokenContext(PROJECTS[0]);
+    if (legacyContext.tokenType === "account") {
+      const projectId = await resolveProjectId(
+        legacyContext.token,
+        legacyContext.apiBase,
+        project,
+      );
+      return { ...legacyContext, projectId };
+    }
+    // Probed as a plain project token: route through resolveProject() so an
+    // unknown/mismatched `project` name is rejected the same way it always
+    // has been, instead of silently serving the one configured token
+    // regardless of what project was actually requested.
+    const validated = resolveProject(project);
+    return {
+      token: validated.token,
+      tokenType: "project",
+      apiBase: validated.apiBase,
+    };
+  }
+
+  // Multiple project-token configs, no account token: fall back to the
+  // existing named-project resolution (will throw a helpful error if the
+  // name is missing/unknown, same as resolveProject()).
+  const fallback = resolveProject(project);
+  return {
+    token: fallback.token,
+    tokenType: "project",
+    apiBase: fallback.apiBase,
+  };
+}
+
+export interface AccountModeInfo {
+  active: boolean;
+  token?: string;
+  apiBase?: string;
+  /**
+   * Number of enabled projects visible to the account token, fetched (and
+   * cached) from GET /projects. Only present when `active` is true — undefined
+   * otherwise. Callers that need to know "does this account resolve to
+   * exactly one project" (e.g. the replay resource's single-vs-multi-project
+   * guard) should use this instead of PROJECTS.length, which is always 0 in
+   * account-token-only mode regardless of how many real projects exist.
+   */
+  enabledProjectCount?: number;
+}
+
+/**
+ * Reports whether the server is currently operating in account-token mode
+ * (an explicit accountToken/ROLLBAR_ACCOUNT_ACCESS_TOKEN, or a legacy
+ * ROLLBAR_ACCESS_TOKEN that the lazy probe determined is actually an
+ * account token) — used by tools/resources that need to branch on "am I
+ * addressing one project or a whole account" without needing to resolve a
+ * specific project id (e.g. list-projects, the replay resource's
+ * single-vs-multi-project guard).
+ */
+export async function getAccountModeInfo(): Promise<AccountModeInfo> {
+  if (ACCOUNT_TOKEN) {
+    const projects = await getProjects(ACCOUNT_TOKEN, DEFAULT_API_BASE);
+    return {
+      active: true,
+      token: ACCOUNT_TOKEN,
+      apiBase: DEFAULT_API_BASE,
+      enabledProjectCount: projects.length,
+    };
+  }
+
+  if (PROJECTS.length === 1 && IS_LEGACY_ENV_TOKEN) {
+    const legacyContext = await resolveLegacyTokenContext(PROJECTS[0]);
+    if (legacyContext.tokenType === "account") {
+      const projects = await getProjects(
+        legacyContext.token,
+        legacyContext.apiBase,
+      );
+      return {
+        active: true,
+        token: legacyContext.token,
+        apiBase: legacyContext.apiBase,
+        enabledProjectCount: projects.length,
+      };
+    }
+  }
+
+  return { active: false };
 }
 
 export function getUserAgent(toolName: string): string {

--- a/src/resources/replay-resource.ts
+++ b/src/resources/replay-resource.ts
@@ -110,8 +110,12 @@ const readReplayResource: ReadResourceTemplateCallback = async (
   variables,
 ) => {
   const accountMode = await getAccountModeInfo();
+  // In a hybrid config (account token + explicit project tokens), each
+  // explicit project entry is an additional addressable project beyond
+  // whatever the account token itself can reach, so it must count toward
+  // the single-project check too.
   const tooManyProjects = accountMode.active
-    ? (accountMode.enabledProjectCount ?? 0) > 1
+    ? (accountMode.enabledProjectCount ?? 0) + PROJECTS.length > 1
     : PROJECTS.length > 1;
   if (tooManyProjects) {
     throw new Error(

--- a/src/resources/replay-resource.ts
+++ b/src/resources/replay-resource.ts
@@ -3,8 +3,14 @@ import type {
   McpServer,
   ReadResourceTemplateCallback,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { PROJECTS, resolveProject } from "../config.js";
+import {
+  PROJECTS,
+  AuthContext,
+  getAccountModeInfo,
+  resolveAuthContext,
+} from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
+import { injectProjectIdQueryParam } from "../utils/params.js";
 import { RollbarApiResponse } from "../types/index.js";
 
 const REPLAY_URI_TEMPLATE =
@@ -79,13 +85,10 @@ export async function fetchReplayData(
   replayId: string,
   token: string,
   apiBase: string,
+  auth?: AuthContext,
 ): Promise<unknown> {
-  const replayUrl = buildReplayApiUrl(
-    apiBase,
-    environment,
-    sessionId,
-    replayId,
-  );
+  const rawUrl = buildReplayApiUrl(apiBase, environment, sessionId, replayId);
+  const replayUrl = auth ? injectProjectIdQueryParam(rawUrl, auth) : rawUrl;
 
   const replayResponse = await makeRollbarRequest<RollbarApiResponse<unknown>>(
     replayUrl,
@@ -106,13 +109,18 @@ const readReplayResource: ReadResourceTemplateCallback = async (
   uri,
   variables,
 ) => {
-  if (PROJECTS.length > 1) {
+  const accountMode = await getAccountModeInfo();
+  const tooManyProjects = accountMode.active
+    ? (accountMode.enabledProjectCount ?? 0) > 1
+    : PROJECTS.length > 1;
+  if (tooManyProjects) {
     throw new Error(
       "Direct replay resource access is not supported when multiple projects are configured. " +
         "Use the get-replay tool with a project parameter instead.",
     );
   }
-  const { token, apiBase } = resolveProject(undefined);
+  const auth = await resolveAuthContext(undefined);
+  const { token, apiBase } = auth;
 
   const environmentValue = normalizeTemplateVariable(variables.environment);
   const sessionValue = normalizeTemplateVariable(variables.sessionId);
@@ -134,7 +142,14 @@ const readReplayResource: ReadResourceTemplateCallback = async (
   const replayData =
     cached !== undefined
       ? cached
-      : await fetchReplayData(environment, sessionId, replayId, token, apiBase);
+      : await fetchReplayData(
+          environment,
+          sessionId,
+          replayId,
+          token,
+          apiBase,
+          auth,
+        );
 
   if (cached === undefined) {
     cacheReplayData(resourceUri, replayData);

--- a/src/tools/get-deployments.ts
+++ b/src/tools/get-deployments.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { resolveAuthContext } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { buildProjectParam } from "../utils/project-params.js";
+import { injectProjectIdQueryParam } from "../utils/params.js";
 import { RollbarApiResponse, RollbarDeployResponse } from "../types/index.js";
 
 export function registerGetDeploymentsTool(server: McpServer) {
@@ -17,8 +18,12 @@ export function registerGetDeploymentsTool(server: McpServer) {
       project: buildProjectParam(),
     },
     async ({ limit, project }) => {
-      const { token, apiBase } = resolveProject(project);
-      const deploysUrl = `${apiBase}/deploys?limit=${limit}`;
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
+      const deploysUrl = injectProjectIdQueryParam(
+        `${apiBase}/deploys?limit=${limit}`,
+        auth,
+      );
       const deploysResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarDeployResponse>
       >(deploysUrl, "get-deployments", token);

--- a/src/tools/get-item-details.ts
+++ b/src/tools/get-item-details.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { resolveAuthContext } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { buildProjectParam } from "../utils/project-params.js";
+import { injectProjectIdQueryParam } from "../utils/params.js";
 import {
   RollbarApiResponse,
   RollbarItemResponse,
@@ -27,8 +28,12 @@ export function registerGetItemDetailsTool(server: McpServer) {
       project: buildProjectParam(),
     },
     async ({ counter, max_tokens, project }) => {
-      const { token, apiBase } = resolveProject(project);
-      const counterUrl = `${apiBase}/item?counter=${counter}`;
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
+      const counterUrl = injectProjectIdQueryParam(
+        `${apiBase}/item?counter=${counter}`,
+        auth,
+      );
       const itemResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarItemResponse>
       >(counterUrl, "get-item-details", token);
@@ -41,7 +46,10 @@ export function registerGetItemDetailsTool(server: McpServer) {
 
       const item = itemResponse.result;
 
-      const occurrenceUrl = `${apiBase}/instance/${item.last_occurrence_id}`;
+      const occurrenceUrl = injectProjectIdQueryParam(
+        `${apiBase}/instance/${item.last_occurrence_id}`,
+        auth,
+      );
       const occurrenceResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarOccurrenceResponse>
       >(occurrenceUrl, "get-item-details", token);

--- a/src/tools/get-replay.ts
+++ b/src/tools/get-replay.ts
@@ -79,8 +79,12 @@ export function registerGetReplayTool(server: McpServer) {
 
       if (deliveryMode === "resource") {
         const accountMode = await getAccountModeInfo();
+        // In a hybrid config (account token + explicit project tokens), each
+        // explicit project entry is an additional addressable project beyond
+        // whatever the account token itself can reach, so it must count
+        // toward the single-project check too.
         const tooManyProjects = accountMode.active
-          ? (accountMode.enabledProjectCount ?? 0) > 1
+          ? (accountMode.enabledProjectCount ?? 0) + PROJECTS.length > 1
           : PROJECTS.length > 1;
         if (tooManyProjects) {
           throw new Error(

--- a/src/tools/get-replay.ts
+++ b/src/tools/get-replay.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { tmpdir } from "node:os";
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { PROJECTS, resolveProject } from "../config.js";
+import { PROJECTS, getAccountModeInfo, resolveAuthContext } from "../config.js";
 import { buildProjectParam } from "../utils/project-params.js";
 import {
   buildReplayResourceUri,
@@ -74,12 +74,19 @@ export function registerGetReplayTool(server: McpServer) {
     },
     async ({ environment, sessionId, replayId, delivery, project }) => {
       const deliveryMode = delivery ?? "file";
-      const { token, apiBase } = resolveProject(project);
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
 
-      if (deliveryMode === "resource" && PROJECTS.length > 1) {
-        throw new Error(
-          'delivery="resource" is not supported when multiple projects are configured. Use delivery="file" and specify the project parameter instead.',
-        );
+      if (deliveryMode === "resource") {
+        const accountMode = await getAccountModeInfo();
+        const tooManyProjects = accountMode.active
+          ? (accountMode.enabledProjectCount ?? 0) > 1
+          : PROJECTS.length > 1;
+        if (tooManyProjects) {
+          throw new Error(
+            'delivery="resource" is not supported when multiple projects are configured. Use delivery="file" and specify the project parameter instead.',
+          );
+        }
       }
 
       const replayData = await fetchReplayData(
@@ -88,6 +95,7 @@ export function registerGetReplayTool(server: McpServer) {
         replayId,
         token,
         apiBase,
+        auth,
       );
 
       const resourceUri = buildReplayResourceUri(

--- a/src/tools/get-top-items.ts
+++ b/src/tools/get-top-items.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { resolveAuthContext } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { buildProjectParam } from "../utils/project-params.js";
+import { injectProjectIdQueryParam } from "../utils/params.js";
 import { RollbarApiResponse, RollbarTopItemResponse } from "../types/index.js";
 
 export function registerGetTopItemsTool(server: McpServer) {
@@ -17,8 +18,12 @@ export function registerGetTopItemsTool(server: McpServer) {
       project: buildProjectParam(),
     },
     async ({ environment, project }) => {
-      const { token, apiBase } = resolveProject(project);
-      const reportUrl = `${apiBase}/reports/top_active_items?hours=24&environments=${environment}&sort=occurrences`;
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
+      const reportUrl = injectProjectIdQueryParam(
+        `${apiBase}/reports/top_active_items?hours=24&environments=${environment}&sort=occurrences`,
+        auth,
+      );
       const reportResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarTopItemResponse>
       >(reportUrl, "get-top-items", token);

--- a/src/tools/get-version.ts
+++ b/src/tools/get-version.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { resolveAuthContext } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { buildProjectParam } from "../utils/project-params.js";
+import { injectProjectIdQueryParam } from "../utils/params.js";
 import { RollbarApiResponse, RollbarVersionsResponse } from "../types/index.js";
 
 export function registerGetVersionTool(server: McpServer) {
@@ -18,8 +19,12 @@ export function registerGetVersionTool(server: McpServer) {
       project: buildProjectParam(),
     },
     async ({ version, environment, project }) => {
-      const { token, apiBase } = resolveProject(project);
-      const versionsUrl = `${apiBase}/versions/${version}?environment=${environment}`;
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
+      const versionsUrl = injectProjectIdQueryParam(
+        `${apiBase}/versions/${version}?environment=${environment}`,
+        auth,
+      );
       const versionsResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarVersionsResponse>
       >(versionsUrl, "get-version", token);

--- a/src/tools/list-items.ts
+++ b/src/tools/list-items.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { resolveAuthContext } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { buildProjectParam } from "../utils/project-params.js";
+import { injectProjectIdsRepeatedQueryParam } from "../utils/params.js";
 import {
   RollbarApiResponse,
   RollbarListItemsResponse,
@@ -71,7 +72,8 @@ export function registerListItemsTool(server: McpServer) {
       query?: string;
       project?: string;
     }) => {
-      const { token, apiBase } = resolveProject(project);
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
       // Build query parameters
       const params = new URLSearchParams();
 
@@ -99,7 +101,10 @@ export function registerListItemsTool(server: McpServer) {
         params.append("query", query);
       }
 
-      const listUrl = `${apiBase}/items/?${params.toString()}`;
+      const listUrl = injectProjectIdsRepeatedQueryParam(
+        `${apiBase}/items/?${params.toString()}`,
+        auth,
+      );
 
       const listResponse = await makeRollbarRequest<
         RollbarApiResponse<RollbarListItemsResponse>

--- a/src/tools/list-projects.ts
+++ b/src/tools/list-projects.ts
@@ -1,12 +1,30 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { PROJECTS } from "../config.js";
+import { PROJECTS, getAccountModeInfo } from "../config.js";
+import { getProjects } from "../utils/projects-cache.js";
 
 export function registerListProjectsTool(server: McpServer) {
   server.tool(
     "list-projects",
     "List configured Rollbar projects available to this MCP server",
     {},
-    () => {
+    async () => {
+      const accountMode = await getAccountModeInfo();
+
+      if (accountMode.active && accountMode.token && accountMode.apiBase) {
+        const projects = await getProjects(
+          accountMode.token,
+          accountMode.apiBase,
+        );
+        const result = projects.map((p) => ({
+          id: p.id,
+          name: p.name,
+          status: p.status,
+        }));
+        return {
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      }
+
       const projects = PROJECTS.map((p) => ({
         name: p.name,
         apiBase: p.apiBase,

--- a/src/tools/update-item.ts
+++ b/src/tools/update-item.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { resolveProject } from "../config.js";
+import { resolveAuthContext } from "../config.js";
 import { makeRollbarRequest } from "../utils/api.js";
 import { buildProjectParam } from "../utils/project-params.js";
+import { injectProjectIdBodyParam } from "../utils/params.js";
 import { RollbarApiResponse } from "../types/index.js";
 
 export function registerUpdateItemTool(server: McpServer) {
@@ -53,7 +54,8 @@ export function registerUpdateItemTool(server: McpServer) {
       teamId,
       project,
     }) => {
-      const { token, apiBase } = resolveProject(project);
+      const auth = await resolveAuthContext(project);
+      const { token, apiBase } = auth;
       const updateData: Record<string, unknown> = {};
 
       if (status !== undefined) updateData.status = status;
@@ -71,6 +73,7 @@ export function registerUpdateItemTool(server: McpServer) {
       }
 
       const url = `${apiBase}/item/${itemId}`;
+      const body = injectProjectIdBodyParam(updateData, auth);
       const response = await makeRollbarRequest<RollbarApiResponse<unknown>>(
         url,
         "update-item",
@@ -80,7 +83,7 @@ export function registerUpdateItemTool(server: McpServer) {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(updateData),
+          body: JSON.stringify(body),
         },
       );
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,5 +1,34 @@
 import { getUserAgent } from "../config.js";
 
+// Builds a short, actionable hint appended to 401/403 error messages,
+// naming the most likely cause instead of leaving the caller with a bare
+// "Unauthorized"/"Forbidden". This is best-effort guidance based on the
+// endpoint and tool involved — it never changes the underlying error.
+function buildAuthErrorHint(
+  status: number,
+  url: string,
+  toolName: string,
+): string {
+  const isProjectsEndpoint = /\/projects(\?|$)/.test(url);
+
+  if (status === 403 && isProjectsEndpoint) {
+    return "This endpoint requires an account access token (GET /projects is account-token-only; a project token returns 403 here). Set ROLLBAR_ACCOUNT_ACCESS_TOKEN or the accountToken config key to use account mode.";
+  }
+
+  if (status === 401) {
+    return "The Rollbar access token appears to be invalid or expired. Check ROLLBAR_ACCESS_TOKEN / ROLLBAR_ACCOUNT_ACCESS_TOKEN (or the token in your .rollbar-mcp.json config).";
+  }
+
+  if (status === 403) {
+    if (toolName === "update-item") {
+      return "The token does not have sufficient privileges for this write operation. update-item requires a token (project or account) with write scope — read-only tokens will get a 403 here.";
+    }
+    return "The token does not have sufficient privileges for this request. Check that it has the required scope (read, or write for update-item) for this project/account.";
+  }
+
+  return "";
+}
+
 // Helper function for making Rollbar API requests
 export async function makeRollbarRequest<T>(
   url: string,
@@ -33,6 +62,13 @@ export async function makeRollbarRequest<T>(
       // If not JSON, include the raw text if it's short
       if (errorText && errorText.length < 200) {
         errorMessage += ` - ${errorText}`;
+      }
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      const hint = buildAuthErrorHint(response.status, url, toolName);
+      if (hint) {
+        errorMessage += ` (${hint})`;
       }
     }
 

--- a/src/utils/params.ts
+++ b/src/utils/params.ts
@@ -1,0 +1,64 @@
+import { AuthContext } from "../config.js";
+
+/**
+ * Appends `project_id=<id>` as a single query param to `url`. No-op
+ * (returns `url` unchanged) when `auth.tokenType !== 'account'` or
+ * `auth.projectId` is not set — project-token mode is never touched.
+ *
+ * Use for: GET /deploys, GET /versions/{v}, GET /reports/top_active_items,
+ * GET /instance/{id}, the replay path, GET /item?counter=.
+ */
+export function injectProjectIdQueryParam(
+  url: string,
+  auth: AuthContext,
+): string {
+  if (auth.tokenType !== "account" || auth.projectId === undefined) {
+    return url;
+  }
+
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}project_id=${encodeURIComponent(auth.projectId)}`;
+}
+
+/**
+ * Merges `project_id` into a JSON request body object. No-op when
+ * `auth.tokenType !== 'account'` or `auth.projectId` is not set.
+ *
+ * Use for: PATCH /item/{id} (update-item).
+ */
+export function injectProjectIdBodyParam<T extends Record<string, unknown>>(
+  body: T,
+  auth: AuthContext,
+): T | (T & { project_id: number }) {
+  if (auth.tokenType !== "account" || auth.projectId === undefined) {
+    return body;
+  }
+
+  return { ...body, project_id: auth.projectId };
+}
+
+/**
+ * Appends a REPEATED `project_ids=<id>` query param to `url`. This is the
+ * one exception in the Rollbar API: GET /items/ (item search / list-items)
+ * takes a `project_ids` LIST, and ONLY as repeated query params.
+ *
+ * A singular `project_id` param, or a comma-joined `project_ids=1,2`, both
+ * hang for ~25s and then return a 422 in production — this function must
+ * NEVER produce either shape. It only ever appends `project_ids=<id>` (the
+ * plural key, one bare numeric value per occurrence).
+ *
+ * No-op when `auth.tokenType !== 'account'` or `auth.projectId` is not set.
+ *
+ * Use for: GET /items/ (list-items).
+ */
+export function injectProjectIdsRepeatedQueryParam(
+  url: string,
+  auth: AuthContext,
+): string {
+  if (auth.tokenType !== "account" || auth.projectId === undefined) {
+    return url;
+  }
+
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}project_ids=${encodeURIComponent(auth.projectId)}`;
+}

--- a/src/utils/project-params.ts
+++ b/src/utils/project-params.ts
@@ -1,7 +1,23 @@
 import { z } from "zod";
-import { PROJECTS } from "../config.js";
+import { HAS_ACCOUNT_TOKEN, PROJECTS } from "../config.js";
 
 export function buildProjectParam() {
+  if (PROJECTS.length === 0 || HAS_ACCOUNT_TOKEN) {
+    // Account-token mode (no project-token entries configured, or a hybrid
+    // config combining explicit project tokens with an account token): the
+    // set of valid project names/ids is dynamic (resolved from the account
+    // token's GET /projects at call time) and/or includes projects beyond
+    // whatever is explicitly listed, so it can't be constrained to a static
+    // zod enum of just the configured names. Accept any string (name or
+    // numeric id) and let resolveAuthContext()/resolveProjectId() validate
+    // and report available names on a miss.
+    return z
+      .string()
+      .optional()
+      .describe(
+        "Project name or numeric id (optional when the account has exactly one enabled project)",
+      );
+  }
   if (PROJECTS.length === 1) {
     return z
       .string()

--- a/src/utils/projects-cache.ts
+++ b/src/utils/projects-cache.ts
@@ -61,11 +61,21 @@ async function getOrFetch(
 
   if (forceRefresh || !entry) {
     const fetchPromise = fetchProjects(token, apiBase);
-    entry = { projects: entry?.projects ?? [], fetchPromise };
+    const previousProjects = entry?.projects ?? [];
+    entry = { projects: previousProjects, fetchPromise };
     cache.set(key, entry);
-    const projects = await fetchPromise;
-    cache.set(key, { projects });
-    return projects;
+    try {
+      const projects = await fetchPromise;
+      cache.set(key, { projects });
+      return projects;
+    } catch (error) {
+      // Fetch failed: drop the rejected promise from the cache so the next
+      // call retries against the API instead of replaying this same
+      // rejection forever, while preserving any previously successful
+      // project list for the caller to fall back on.
+      cache.set(key, { projects: previousProjects });
+      throw error;
+    }
   }
 
   if (entry.fetchPromise) {

--- a/src/utils/projects-cache.ts
+++ b/src/utils/projects-cache.ts
@@ -1,0 +1,161 @@
+import { RollbarApiResponse } from "../types/index.js";
+
+export interface RollbarProject {
+  id: number;
+  name: string;
+  status: string;
+  account_id?: number;
+  [key: string]: unknown;
+}
+
+interface CacheEntry {
+  projects: RollbarProject[];
+  fetchPromise?: Promise<RollbarProject[]>;
+}
+
+// Cache is keyed by `${apiBase}::${token}` so multiple account tokens (in
+// theory) or api bases don't collide, and is intentionally process-lifetime:
+// we never refetch on our own initiative, only on an explicit lookup miss.
+const cache = new Map<string, CacheEntry>();
+
+function cacheKey(token: string, apiBase: string): string {
+  return `${apiBase}::${token}`;
+}
+
+async function fetchProjects(
+  token: string,
+  apiBase: string,
+): Promise<RollbarProject[]> {
+  const response = await fetch(`${apiBase}/projects`, {
+    headers: {
+      "X-Rollbar-Access-Token": token,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Rollbar projects: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const body = (await response.json()) as RollbarApiResponse<RollbarProject[]>;
+  if (body.err !== 0) {
+    throw new Error(
+      `Rollbar API returned error fetching projects: ${
+        body.message || `Unknown error (code: ${body.err})`
+      }`,
+    );
+  }
+
+  return (body.result || []).filter((p) => p.status === "enabled");
+}
+
+async function getOrFetch(
+  token: string,
+  apiBase: string,
+  forceRefresh: boolean,
+): Promise<RollbarProject[]> {
+  const key = cacheKey(token, apiBase);
+  let entry = cache.get(key);
+
+  if (forceRefresh || !entry) {
+    const fetchPromise = fetchProjects(token, apiBase);
+    entry = { projects: entry?.projects ?? [], fetchPromise };
+    cache.set(key, entry);
+    const projects = await fetchPromise;
+    cache.set(key, { projects });
+    return projects;
+  }
+
+  if (entry.fetchPromise) {
+    return entry.fetchPromise;
+  }
+
+  return entry.projects;
+}
+
+/**
+ * Returns the cached list of enabled projects for this account token,
+ * fetching from GET /projects on first use. Never refetches automatically
+ * on subsequent calls — only refreshOnce() (used internally by
+ * resolveProjectId on a lookup miss) forces a refetch.
+ */
+export async function getProjects(
+  token: string,
+  apiBase: string,
+): Promise<RollbarProject[]> {
+  return getOrFetch(token, apiBase, false);
+}
+
+function matchProject(
+  projects: RollbarProject[],
+  identifier: string,
+): RollbarProject | undefined {
+  const trimmed = identifier.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const numericId = Number(trimmed);
+    const byId = projects.find((p) => p.id === numericId);
+    if (byId) return byId;
+  }
+  const lower = trimmed.toLowerCase();
+  return projects.find((p) => p.name.toLowerCase() === lower);
+}
+
+/**
+ * Resolves a `project` request param (name, case-insensitive, or numeric id)
+ * to a Rollbar project id using the cached project list for this account
+ * token. If there's no match, the cache is refreshed once (in case a new
+ * project was added since the last fetch) and the match retried before
+ * throwing an error listing the available project names.
+ *
+ * If `project` is undefined and the account has exactly one enabled
+ * project, that project is auto-selected as the default.
+ */
+export async function resolveProjectId(
+  token: string,
+  apiBase: string,
+  project: string | undefined,
+): Promise<number> {
+  let projects = await getProjects(token, apiBase);
+
+  if (project === undefined) {
+    if (projects.length === 1) {
+      return projects[0].id;
+    }
+    if (projects.length === 0) {
+      // Give the refresh-once behavior a chance in case the cache was
+      // populated before any projects existed on the account.
+      projects = await getOrFetch(token, apiBase, true);
+      if (projects.length === 1) {
+        return projects[0].id;
+      }
+    }
+    throw new Error(
+      projects.length === 0
+        ? "No enabled Rollbar projects found for this account token."
+        : `Multiple projects available on this account token. Specify a project. Available: ${projects.map((p) => p.name).join(", ")}`,
+    );
+  }
+
+  const match = matchProject(projects, project);
+  if (match) {
+    return match.id;
+  }
+
+  // Lookup miss: refresh once in case a new project was added, then retry.
+  const refreshed = await getOrFetch(token, apiBase, true);
+  const retryMatch = matchProject(refreshed, project);
+  if (retryMatch) {
+    return retryMatch.id;
+  }
+
+  throw new Error(
+    `Unknown project "${project}". Available: ${refreshed.map((p) => p.name).join(", ")}`,
+  );
+}
+
+/** Test-only helper to reset the process-lifetime cache between tests. */
+export function __resetProjectsCacheForTests(): void {
+  cache.clear();
+}

--- a/tests/integration/server.test.ts
+++ b/tests/integration/server.test.ts
@@ -5,6 +5,7 @@ import { registerAllTools } from '../../src/tools/index.js';
 
 // Mock the config to provide PROJECTS and resolveProject
 vi.mock('../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',

--- a/tests/unit/config-account-token.test.ts
+++ b/tests/unit/config-account-token.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("dotenv", () => ({
+  default: {
+    config: vi.fn(),
+  },
+}));
+
+const existsSyncMock = vi.fn();
+const readFileSyncMock = vi.fn();
+vi.mock("node:fs", () => ({
+  existsSync: (path: string) => existsSyncMock(path),
+  readFileSync: (path: string, ...args: unknown[]) =>
+    readFileSyncMock(path, ...args),
+}));
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  };
+}
+
+describe("config — account access token support", () => {
+  const originalEnv = process.env;
+  const originalExit = process.exit;
+  const originalConsoleError = console.error;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.ROLLBAR_ACCESS_TOKEN;
+    delete process.env.ROLLBAR_ACCOUNT_ACCESS_TOKEN;
+    delete process.env.ROLLBAR_API_BASE;
+    delete process.env.ROLLBAR_CONFIG_FILE;
+    process.exit = vi.fn() as typeof process.exit;
+    console.error = vi.fn();
+    existsSyncMock.mockReturnValue(false);
+    readFileSyncMock.mockReset();
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.exit = originalExit;
+    console.error = originalConsoleError;
+    vi.clearAllMocks();
+  });
+
+  describe("explicit account token via env var", () => {
+    it("activates account mode via ROLLBAR_ACCOUNT_ACCESS_TOKEN and resolves project ids from GET /projects", async () => {
+      process.env.ROLLBAR_ACCOUNT_ACCESS_TOKEN = "acct-env-token";
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [
+            { id: 11, name: "Backend", status: "enabled" },
+            { id: 12, name: "Frontend", status: "enabled" },
+          ],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext("Backend");
+
+      expect(ctx.tokenType).toBe("account");
+      expect(ctx.token).toBe("acct-env-token");
+      expect(ctx.projectId).toBe(11);
+    });
+  });
+
+  describe("explicit account token via config file key", () => {
+    it("activates account mode via accountToken in a multi-project config file", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          accountToken: "acct-file-token",
+          projects: [{ name: "backend", token: "tok_backend" }],
+        }),
+      );
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 99, name: "SomeProject", status: "enabled" }],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext("SomeProject");
+
+      expect(ctx.tokenType).toBe("account");
+      expect(ctx.token).toBe("acct-file-token");
+      expect(ctx.projectId).toBe(99);
+    });
+
+    it("activates account mode via accountToken alone (account-token-only config file, no projects/token)", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          accountToken: "acct-file-token-2",
+        }),
+      );
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 42, name: "OnlyProject", status: "enabled" }],
+        }),
+      );
+
+      const { resolveAuthContext, PROJECTS } = await import(
+        "../../src/config.js"
+      );
+
+      // This is the documented README example: { "accountToken": "..." }
+      // with no "projects" and no "token". It must not crash the server.
+      expect(process.exit).not.toHaveBeenCalled();
+      expect(PROJECTS).toEqual([]);
+
+      const ctx = await resolveAuthContext(undefined);
+      expect(ctx.tokenType).toBe("account");
+      expect(ctx.token).toBe("acct-file-token-2");
+      expect(ctx.projectId).toBe(42);
+    });
+  });
+
+  describe("probe fallback (legacy ROLLBAR_ACCESS_TOKEN only)", () => {
+    it("200 response from GET /projects => treated as account token", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-token";
+      // First call is the probe itself; second is the projects-cache fetch
+      // used to resolve the projectId once we know it's an account token.
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 5, name: "OnlyProject", status: "enabled" }],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext(undefined);
+
+      expect(ctx.tokenType).toBe("account");
+      expect(ctx.token).toBe("legacy-token");
+      expect(ctx.projectId).toBe(5);
+    });
+
+    it("401/403 response from GET /projects => treated as project token, current behavior unchanged", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-project-token";
+      fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 403));
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext(undefined);
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("legacy-project-token");
+      expect(ctx.projectId).toBeUndefined();
+    });
+
+    it("REGRESSION: rejects a project name that does not match the legacy token's synthesized project, instead of silently serving it", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-project-token";
+      fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 403));
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+
+      // A caller requesting "frontend" against a legacy env-var token
+      // (synthesized as project name "default") must be rejected the same
+      // way an explicit multi-project config rejects an unknown name — not
+      // silently served the one configured token regardless of what project
+      // was actually asked for.
+      await expect(resolveAuthContext("frontend")).rejects.toThrow(
+        'Unknown project "frontend". Available: default',
+      );
+    });
+
+    it("still resolves the sole project when the legacy token's own synthesized name ('default') is passed explicitly", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-project-token";
+      fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 403));
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext("default");
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("legacy-project-token");
+    });
+
+    it("network error during probe => logs a warning and falls back to project-token behavior", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-project-token";
+      fetchMock.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext(undefined);
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("legacy-project-token");
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining("Warning"),
+      );
+    });
+
+    it("only probes once for the process lifetime — second resolveAuthContext call reuses cached probe + cached project list", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-token";
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 5, name: "OnlyProject", status: "enabled" }],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      await resolveAuthContext(undefined);
+      const callsAfterFirst = fetchMock.mock.calls.length;
+      await resolveAuthContext(undefined);
+
+      // The probe (GET /projects) and the projects-cache fetch (also GET
+      // /projects) each happen exactly once on the first call; the second
+      // call must not trigger any additional fetch — both the probe result
+      // and the projects cache are reused.
+      expect(callsAfterFirst).toBe(2);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("coexistence: explicit project token wins over a present account token", () => {
+    it("an explicitly-listed project's own token wins over the account token for that project name", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          accountToken: "acct-token",
+          projects: [{ name: "backend", token: "tok_backend_explicit" }],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext("backend");
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("tok_backend_explicit");
+      // The account-token path (GET /projects) must never be consulted when
+      // an explicit project token satisfies the request.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to account mode for a project not explicitly configured", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          accountToken: "acct-token",
+          projects: [{ name: "backend", token: "tok_backend_explicit" }],
+        }),
+      );
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [
+            { id: 1, name: "backend", status: "enabled" },
+            { id: 2, name: "frontend", status: "enabled" },
+          ],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext("frontend");
+
+      expect(ctx.tokenType).toBe("account");
+      expect(ctx.token).toBe("acct-token");
+      expect(ctx.projectId).toBe(2);
+    });
+  });
+
+  describe("REGRESSION: single-project config-file setup (not the legacy env var) must never probe", () => {
+    it("does not call GET /projects (or fetch at all) for a single-project shorthand config file with no account token", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({ token: "tok_from_file" }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext(undefined);
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("tok_from_file");
+      // The whole point of this regression test: only the legacy
+      // ROLLBAR_ACCESS_TOKEN-only path may lazily probe GET /projects. A
+      // single project sourced from a config file is unambiguously
+      // project-token-only and must never trigger any network call.
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("does not call fetch for a single-project multi-project-shaped config file (one entry in `projects`) with no account token", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          projects: [{ name: "solo", token: "tok_solo" }],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext(undefined);
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("tok_solo");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("getAccountModeInfo() also does not probe for a single-project config-file setup", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({ token: "tok_from_file" }),
+      );
+
+      const { getAccountModeInfo } = await import("../../src/config.js");
+      const info = await getAccountModeInfo();
+
+      expect(info.active).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("multiple project-token configs, no account token", () => {
+    it("resolveAuthContext falls back to named-project resolution", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          projects: [
+            { name: "backend", token: "tok_1" },
+            { name: "frontend", token: "tok_2" },
+          ],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      const ctx = await resolveAuthContext("frontend");
+
+      expect(ctx.tokenType).toBe("project");
+      expect(ctx.token).toBe("tok_2");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("resolveAuthContext(undefined) throws the same helpful error as resolveProject", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          projects: [
+            { name: "backend", token: "tok_1" },
+            { name: "frontend", token: "tok_2" },
+          ],
+        }),
+      );
+
+      const { resolveAuthContext } = await import("../../src/config.js");
+      await expect(resolveAuthContext(undefined)).rejects.toThrow(
+        /Multiple projects configured/,
+      );
+    });
+  });
+
+  describe("resolveProject() in pure account-mode (zero project-token projects)", () => {
+    it("throws a clear account-mode error instead of the multi-project message", async () => {
+      process.env.ROLLBAR_ACCOUNT_ACCESS_TOKEN = "acct-only-token";
+
+      const { resolveProject } = await import("../../src/config.js");
+      expect(() => resolveProject(undefined)).toThrow(/account-token mode/);
+    });
+  });
+
+  describe("getAccountModeInfo", () => {
+    it("reports active with token/apiBase when an explicit account token is configured", async () => {
+      process.env.ROLLBAR_ACCOUNT_ACCESS_TOKEN = "acct-env-token";
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [
+            { id: 1, name: "One", status: "enabled" },
+            { id: 2, name: "Two", status: "enabled" },
+          ],
+        }),
+      );
+
+      const { getAccountModeInfo } = await import("../../src/config.js");
+      const info = await getAccountModeInfo();
+
+      expect(info.active).toBe(true);
+      expect(info.token).toBe("acct-env-token");
+      expect(info.apiBase).toBe("https://api.rollbar.com/api/1");
+      expect(info.enabledProjectCount).toBe(2);
+    });
+
+    it("reports inactive for a plain project-token config", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "plain-project-token";
+      fetchMock.mockResolvedValueOnce(jsonResponse({}, false, 401));
+
+      const { getAccountModeInfo } = await import("../../src/config.js");
+      const info = await getAccountModeInfo();
+
+      expect(info.active).toBe(false);
+    });
+
+    it("reports active when the legacy single token probes as an account token", async () => {
+      process.env.ROLLBAR_ACCESS_TOKEN = "legacy-token";
+      // First call is the probe itself (GET /projects, 200 => account);
+      // second is the getProjects() call getAccountModeInfo() makes to
+      // report enabledProjectCount.
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 1, name: "Solo", status: "enabled" }],
+        }),
+      );
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 1, name: "Solo", status: "enabled" }],
+        }),
+      );
+
+      const { getAccountModeInfo } = await import("../../src/config.js");
+      const info = await getAccountModeInfo();
+
+      expect(info.active).toBe(true);
+      expect(info.token).toBe("legacy-token");
+      expect(info.enabledProjectCount).toBe(1);
+    });
+
+    it("reports inactive when multiple project-token configs are present with no account token", async () => {
+      existsSyncMock.mockImplementation((p: string) =>
+        p.endsWith(".rollbar-mcp.json"),
+      );
+      readFileSyncMock.mockReturnValue(
+        JSON.stringify({
+          projects: [
+            { name: "backend", token: "tok_1" },
+            { name: "frontend", token: "tok_2" },
+          ],
+        }),
+      );
+
+      const { getAccountModeInfo } = await import("../../src/config.js");
+      const info = await getAccountModeInfo();
+
+      expect(info.active).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/config.vitest.test.ts
+++ b/tests/unit/config.vitest.test.ts
@@ -290,7 +290,7 @@ describe("config", () => {
     await import("../../src/config.js");
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("expected either a single-project config"),
+      expect.stringContaining("expected an account-only config"),
     );
     expect(process.exit).toHaveBeenCalledWith(1);
   });

--- a/tests/unit/resources/replay-resource.test.ts
+++ b/tests/unit/resources/replay-resource.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -20,6 +21,12 @@ vi.mock('../../../src/config.js', () => ({
     token: 'test-token',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getAccountModeInfo: vi.fn(async () => ({ active: false })),
 }));
 
 let makeRollbarRequestMock: any;
@@ -152,11 +159,14 @@ describe('read replay resource handler', () => {
   it('throws when PROJECTS.length > 1 with message to use get-replay tool', async () => {
     vi.resetModules();
     vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: false,
       PROJECTS: [
         { name: 'backend', token: 't1', apiBase: 'https://api.rollbar.com/api/1' },
         { name: 'frontend', token: 't2', apiBase: 'https://api.rollbar.com/api/1' },
       ],
       resolveProject: vi.fn(),
+      resolveAuthContext: vi.fn(),
+      getAccountModeInfo: vi.fn(async () => ({ active: false })),
     }));
     const replayMod = await import('../../../src/resources/replay-resource.js');
     let multiProjectReadCallback: typeof readCallback;
@@ -175,5 +185,137 @@ describe('read replay resource handler', () => {
     await expect(
       multiProjectReadCallback!(uri, { environment, sessionId, replayId })
     ).rejects.toThrow('get-replay tool');
+  });
+
+  it('allows direct replay resource access in account mode even when PROJECTS.length > 1, and injects project_id', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: false,
+      PROJECTS: [
+        { name: 'backend', token: 't1', apiBase: 'https://api.rollbar.com/api/1' },
+        { name: 'frontend', token: 't2', apiBase: 'https://api.rollbar.com/api/1' },
+      ],
+      resolveProject: vi.fn(),
+      resolveAuthContext: vi.fn(async () => ({
+        token: 'acct-token',
+        tokenType: 'account',
+        projectId: 9,
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getAccountModeInfo: vi.fn(async () => ({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+    }));
+
+    const { makeRollbarRequest } = await import('../../../src/utils/api.js');
+    const localMakeRollbarRequestMock = makeRollbarRequest as any;
+    localMakeRollbarRequestMock.mockResolvedValue({
+      err: 0,
+      result: mockSuccessfulReplayResponse.result,
+    });
+
+    const replayMod = await import('../../../src/resources/replay-resource.js');
+    let accountModeReadCallback: typeof readCallback;
+    const resourceSpy3 = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
+      accountModeReadCallback = handler as typeof readCallback;
+    });
+    const server3 = { resource: resourceSpy3 } as any;
+    replayMod.registerReplayResource(server3);
+
+    const uri = new URL(replayUri);
+    await accountModeReadCallback!(uri, { environment, sessionId, replayId });
+
+    expect(localMakeRollbarRequestMock).toHaveBeenCalledWith(
+      `https://api.rollbar.com/api/1/environment/${environment}/session/${sessionId}/replay/${replayId}?project_id=9`,
+      'get-replay',
+      'acct-token'
+    );
+  });
+
+  it('propagates a clear error (does not silently proceed unresolved) when account mode has multiple projects and resolveAuthContext cannot pick one', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: false,
+      PROJECTS: [],
+      resolveProject: vi.fn(),
+      // Mirrors what the real resolveAuthContext()/resolveProjectId() do when
+      // an account token has 2+ enabled projects and no `project` was given:
+      // they throw rather than resolving a projectId. The read-resource
+      // handler must let that propagate as an error, not fall through to an
+      // unscoped/broken account-mode request.
+      resolveAuthContext: vi.fn(async () => {
+        throw new Error(
+          'Multiple projects available on this account token. Specify a project. Available: backend, frontend'
+        );
+      }),
+      getAccountModeInfo: vi.fn(async () => ({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+    }));
+
+    const { makeRollbarRequest } = await import('../../../src/utils/api.js');
+    const localMakeRollbarRequestMock = makeRollbarRequest as any;
+
+    const replayMod = await import('../../../src/resources/replay-resource.js');
+    let noProjectReadCallback: typeof readCallback;
+    const resourceSpy4 = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
+      noProjectReadCallback = handler as typeof readCallback;
+    });
+    const server4 = { resource: resourceSpy4 } as any;
+    replayMod.registerReplayResource(server4);
+
+    const uri = new URL(replayUri);
+    await expect(
+      noProjectReadCallback!(uri, { environment, sessionId, replayId })
+    ).rejects.toThrow('Multiple projects available on this account token');
+
+    // The request must never have been made without a resolved project.
+    expect(localMakeRollbarRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct resource access up front (before calling resolveAuthContext) when account mode has multiple enabled projects', async () => {
+    vi.resetModules();
+    // PROJECTS is empty (account-token-only mode). Before the fix, this
+    // guard checked `PROJECTS.length > 1 && !accountMode.active`, which is
+    // always false here regardless of enabledProjectCount, so the guard
+    // never fired and execution fell through to resolveAuthContext(undefined)
+    // instead of failing with this resource's own clear error message.
+    const resolveAuthContextMock = vi.fn();
+    vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: true,
+      PROJECTS: [],
+      resolveAuthContext: resolveAuthContextMock,
+      getAccountModeInfo: vi.fn(async () => ({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+        enabledProjectCount: 2,
+      })),
+    }));
+
+    const { makeRollbarRequest } = await import('../../../src/utils/api.js');
+    const localMakeRollbarRequestMock = makeRollbarRequest as any;
+
+    const replayMod = await import('../../../src/resources/replay-resource.js');
+    let guardReadCallback: typeof readCallback;
+    const resourceSpy5 = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
+      guardReadCallback = handler as typeof readCallback;
+    });
+    const server5 = { resource: resourceSpy5 } as any;
+    replayMod.registerReplayResource(server5);
+
+    const uri = new URL(replayUri);
+    await expect(
+      guardReadCallback!(uri, { environment, sessionId, replayId })
+    ).rejects.toThrow(
+      'Direct replay resource access is not supported when multiple projects are configured'
+    );
+
+    expect(resolveAuthContextMock).not.toHaveBeenCalled();
+    expect(localMakeRollbarRequestMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/resources/replay-resource.test.ts
+++ b/tests/unit/resources/replay-resource.test.ts
@@ -187,14 +187,53 @@ describe('read replay resource handler', () => {
     ).rejects.toThrow('get-replay tool');
   });
 
-  it('allows direct replay resource access in account mode even when PROJECTS.length > 1, and injects project_id', async () => {
+  it('rejects direct replay resource access in a hybrid config (account token + explicit project tokens) when the combined addressable project count exceeds one', async () => {
     vi.resetModules();
+    // Hybrid config: an account token that alone resolves to a single
+    // enabled project, plus two explicit project-token entries. Before the
+    // fix, the guard only counted accountMode.enabledProjectCount (1) and
+    // ignored PROJECTS entirely, so `1 > 1` was false and this incorrectly
+    // fell through to resolveAuthContext(undefined) -- which, per its own
+    // precedence rules, has no way to know which of the 3 addressable
+    // projects the request meant. The guard must count PROJECTS.length
+    // toward the total so this case is rejected up front instead.
     vi.doMock('../../../src/config.js', () => ({
-      HAS_ACCOUNT_TOKEN: false,
+      HAS_ACCOUNT_TOKEN: true,
       PROJECTS: [
         { name: 'backend', token: 't1', apiBase: 'https://api.rollbar.com/api/1' },
         { name: 'frontend', token: 't2', apiBase: 'https://api.rollbar.com/api/1' },
       ],
+      resolveProject: vi.fn(),
+      resolveAuthContext: vi.fn(),
+      getAccountModeInfo: vi.fn(async () => ({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+        enabledProjectCount: 1,
+      })),
+    }));
+
+    const replayMod = await import('../../../src/resources/replay-resource.js');
+    let hybridReadCallback: typeof readCallback;
+    const resourceSpy3 = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
+      hybridReadCallback = handler as typeof readCallback;
+    });
+    const server3 = { resource: resourceSpy3 } as any;
+    replayMod.registerReplayResource(server3);
+
+    const uri = new URL(replayUri);
+    await expect(
+      hybridReadCallback!(uri, { environment, sessionId, replayId })
+    ).rejects.toThrow(
+      'Direct replay resource access is not supported when multiple projects are configured'
+    );
+  });
+
+  it('allows direct replay resource access in pure account mode with exactly one enabled project and no explicit project tokens, and injects project_id', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: true,
+      PROJECTS: [],
       resolveProject: vi.fn(),
       resolveAuthContext: vi.fn(async () => ({
         token: 'acct-token',
@@ -206,6 +245,7 @@ describe('read replay resource handler', () => {
         active: true,
         token: 'acct-token',
         apiBase: 'https://api.rollbar.com/api/1',
+        enabledProjectCount: 1,
       })),
     }));
 
@@ -218,11 +258,11 @@ describe('read replay resource handler', () => {
 
     const replayMod = await import('../../../src/resources/replay-resource.js');
     let accountModeReadCallback: typeof readCallback;
-    const resourceSpy3 = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
+    const resourceSpyAccountOnly = vi.fn((_n: string, _t: unknown, _m: unknown, handler: unknown) => {
       accountModeReadCallback = handler as typeof readCallback;
     });
-    const server3 = { resource: resourceSpy3 } as any;
-    replayMod.registerReplayResource(server3);
+    const serverAccountOnly = { resource: resourceSpyAccountOnly } as any;
+    replayMod.registerReplayResource(serverAccountOnly);
 
     const uri = new URL(replayUri);
     await accountModeReadCallback!(uri, { environment, sessionId, replayId });

--- a/tests/unit/tools/get-deployments.test.ts
+++ b/tests/unit/tools/get-deployments.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -18,6 +19,11 @@ vi.mock('../../../src/config.js', () => ({
   resolveProject: vi.fn(() => ({
     name: 'default',
     token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
@@ -153,5 +159,24 @@ describe('get-deployments tool', () => {
     await toolHandler({ limit: 10 });
 
     expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('should inject project_id as a query param in account mode', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 55,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulDeployResponse);
+
+    await toolHandler({ limit: 10, project: 'SomeProject' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/deploys?limit=10&project_id=55',
+      'get-deployments',
+      'acct-token'
+    );
   });
 });

--- a/tests/unit/tools/get-item-details.test.ts
+++ b/tests/unit/tools/get-item-details.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -18,6 +19,11 @@ vi.mock('../../../src/config.js', () => ({
   resolveProject: vi.fn(() => ({
     name: 'default',
     token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
@@ -311,6 +317,47 @@ describe('get-item-details tool', () => {
     );
     const responseData = JSON.parse(result.content[0].text);
     expect(responseData).toHaveProperty('counter', 42);
+  });
+
+  it('should inject project_id as a query param when resolveAuthContext returns account mode', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 77,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
+
+    await toolHandler({ counter: 42, project: 'SomeProject' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/item?counter=42&project_id=77',
+      'get-item-details',
+      'acct-token'
+    );
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/instance/999?project_id=77',
+      'get-item-details',
+      'acct-token'
+    );
+  });
+
+  it('should NOT inject project_id when resolveAuthContext returns project mode (unchanged behavior)', async () => {
+    makeRollbarRequestMock
+      .mockResolvedValueOnce(mockSuccessfulItemResponse)
+      .mockResolvedValueOnce(mockSuccessfulOccurrenceResponse);
+
+    await toolHandler({ counter: 42 });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/item?counter=42',
+      'get-item-details',
+      'test-token'
+    );
   });
 
   it('should validate max_tokens parameter with Zod schema', () => {

--- a/tests/unit/tools/get-replay.test.ts
+++ b/tests/unit/tools/get-replay.test.ts
@@ -18,6 +18,7 @@ vi.mock('node:fs/promises', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -30,6 +31,12 @@ vi.mock('../../../src/config.js', () => ({
     token: 'test-token',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  getAccountModeInfo: vi.fn(async () => ({ active: false })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
 }));
 
@@ -215,9 +222,34 @@ describe('get-replay tool', () => {
     );
   });
 
+  it('should inject project_id as a query param on the replay path in account mode', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 66,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulReplayResponse);
+
+    await toolHandler({
+      environment: 'production',
+      sessionId: 'session-123',
+      replayId: 'replay-456',
+      project: 'SomeProject',
+    });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/environment/production/session/session-123/replay/replay-456?project_id=66',
+      'get-replay',
+      'acct-token'
+    );
+  });
+
   it('should reject delivery=resource when multiple projects are configured', async () => {
     vi.resetModules();
     vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: false,
       PROJECTS: [
         { name: 'backend', token: 'token-1', apiBase: 'https://api.rollbar.com/api/1' },
         { name: 'frontend', token: 'token-2', apiBase: 'https://api.rollbar.com/api/1' },
@@ -227,6 +259,12 @@ describe('get-replay tool', () => {
         token: 'token-1',
         apiBase: 'https://api.rollbar.com/api/1',
       })),
+      resolveAuthContext: vi.fn(async () => ({
+        token: 'token-1',
+        tokenType: 'project',
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getAccountModeInfo: vi.fn(async () => ({ active: false })),
       getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
     }));
 
@@ -257,9 +295,102 @@ describe('get-replay tool', () => {
     );
   });
 
+  it('should reject delivery=resource in account-token-only mode when the account has multiple enabled projects', async () => {
+    vi.resetModules();
+    // PROJECTS is empty here — this is account-token-only mode. Before the
+    // fix, the guard checked PROJECTS.length > 1, which is always false in
+    // this mode regardless of how many real projects the account has, so
+    // this rejection never fired and a resource link that could never be
+    // read was returned instead.
+    vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: true,
+      PROJECTS: [],
+      resolveAuthContext: vi.fn(async () => ({
+        token: 'acct-token',
+        tokenType: 'account',
+        projectId: 1,
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getAccountModeInfo: vi.fn(async () => ({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+        enabledProjectCount: 2,
+      })),
+      getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
+    }));
+
+    const { registerGetReplayTool: register } = await import('../../../src/tools/get-replay.js');
+    let localToolHandler: any;
+    const localServer = {
+      tool: vi.fn((_name, _description, _schema, handler) => {
+        localToolHandler = handler;
+      }),
+    } as any;
+
+    register(localServer);
+
+    await expect(
+      localToolHandler({
+        environment: 'production',
+        sessionId: 'session-123',
+        replayId: 'replay-456',
+        project: 'SomeAccountProject',
+        delivery: 'resource',
+      })
+    ).rejects.toThrow(
+      'delivery="resource" is not supported when multiple projects are configured'
+    );
+  });
+
+  it('should allow delivery=resource in account-token mode when the account has exactly one enabled project', async () => {
+    vi.resetModules();
+    vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: true,
+      PROJECTS: [],
+      resolveAuthContext: vi.fn(async () => ({
+        token: 'acct-token',
+        tokenType: 'account',
+        projectId: 42,
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getAccountModeInfo: vi.fn(async () => ({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+        enabledProjectCount: 1,
+      })),
+      getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
+    }));
+
+    const { makeRollbarRequest } = await import('../../../src/utils/api.js');
+    const localMakeRollbarRequestMock = makeRollbarRequest as any;
+    localMakeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulReplayResponse);
+
+    const { registerGetReplayTool: register } = await import('../../../src/tools/get-replay.js');
+    let localToolHandler: any;
+    const localServer = {
+      tool: vi.fn((_name, _description, _schema, handler) => {
+        localToolHandler = handler;
+      }),
+    } as any;
+
+    register(localServer);
+
+    const result = await localToolHandler({
+      environment: 'production',
+      sessionId: 'session-123',
+      replayId: 'replay-456',
+      delivery: 'resource',
+    });
+
+    expect(result.content[1].type).toBe('resource_link');
+  });
+
   it('should still allow delivery=file when multiple projects are configured', async () => {
     vi.resetModules();
     vi.doMock('../../../src/config.js', () => ({
+      HAS_ACCOUNT_TOKEN: false,
       PROJECTS: [
         { name: 'backend', token: 'token-1', apiBase: 'https://api.rollbar.com/api/1' },
         { name: 'frontend', token: 'token-2', apiBase: 'https://api.rollbar.com/api/1' },
@@ -269,6 +400,12 @@ describe('get-replay tool', () => {
         token: 'token-1',
         apiBase: 'https://api.rollbar.com/api/1',
       })),
+      resolveAuthContext: vi.fn(async () => ({
+        token: 'token-1',
+        tokenType: 'project',
+        apiBase: 'https://api.rollbar.com/api/1',
+      })),
+      getAccountModeInfo: vi.fn(async () => ({ active: false })),
       getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
     }));
 

--- a/tests/unit/tools/get-top-items.test.ts
+++ b/tests/unit/tools/get-top-items.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -18,6 +19,11 @@ vi.mock('../../../src/config.js', () => ({
   resolveProject: vi.fn(() => ({
     name: 'default',
     token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
@@ -161,6 +167,25 @@ describe('get-top-items tool', () => {
       'https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=production&sort=occurrences',
       'get-top-items',
       'test-token'
+    );
+  });
+
+  it('should inject project_id as a query param in account mode', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 88,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulTopItemsResponse);
+
+    await toolHandler({ environment: 'production', project: 'SomeProject' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=production&sort=occurrences&project_id=88',
+      'get-top-items',
+      'acct-token'
     );
   });
 });

--- a/tests/unit/tools/get-version.test.ts
+++ b/tests/unit/tools/get-version.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -18,6 +19,11 @@ vi.mock('../../../src/config.js', () => ({
   resolveProject: vi.fn(() => ({
     name: 'default',
     token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
@@ -177,6 +183,25 @@ describe('get-version tool', () => {
       'https://api.rollbar.com/api/1/versions/v1?environment=production',
       'get-version',
       'test-token'
+    );
+  });
+
+  it('should inject project_id as a query param in account mode', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 21,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulVersionResponse);
+
+    await toolHandler({ version: 'v1', environment: 'production', project: 'SomeProject' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/versions/v1?environment=production&project_id=21',
+      'get-version',
+      'acct-token'
     );
   });
 });

--- a/tests/unit/tools/list-items.test.ts
+++ b/tests/unit/tools/list-items.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -18,6 +19,11 @@ vi.mock('../../../src/config.js', () => ({
   resolveProject: vi.fn(() => ({
     name: 'default',
     token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
@@ -237,5 +243,28 @@ describe('list-items tool', () => {
     expect(urlCall).toContain('level=error');
     expect(urlCall).toContain('level=warning');
     expect(urlCall).toContain('level=critical');
+  });
+
+  it('should inject a REPEATED project_ids query param in account mode (never singular project_id, never comma-joined)', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 33,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    makeRollbarRequestMock.mockResolvedValueOnce(mockSuccessfulListItemsResponse);
+
+    await toolHandler({ status: 'active', environment: 'production', project: 'SomeProject' });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/items/?status=active&environment=production&project_ids=33',
+      'list-items',
+      'acct-token'
+    );
+
+    const urlCall = makeRollbarRequestMock.mock.calls[0][0];
+    expect(urlCall).not.toMatch(/[?&]project_id=/);
+    expect(urlCall).not.toContain(',');
   });
 });

--- a/tests/unit/tools/list-projects.test.ts
+++ b/tests/unit/tools/list-projects.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { registerListProjectsTool } from '../../../src/tools/list-projects.js';
 
+vi.mock('../../../src/utils/projects-cache.js', () => ({
+  getProjects: vi.fn(),
+}));
+
 vi.mock('../../../src/config.js', () => ({
   PROJECTS: [
     {
@@ -10,6 +14,7 @@ vi.mock('../../../src/config.js', () => ({
       apiBase: 'https://api.rollbar.com/api/1',
     },
   ],
+  getAccountModeInfo: vi.fn(async () => ({ active: false })),
 }));
 
 describe('list-projects tool', () => {
@@ -17,6 +22,9 @@ describe('list-projects tool', () => {
   let toolHandler: (args: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }>;
 
   beforeEach(async () => {
+    const { getAccountModeInfo } = await import('../../../src/config.js');
+    (getAccountModeInfo as any).mockResolvedValue({ active: false });
+
     server = {
       tool: vi.fn((_name, _description, _schema, handler) => {
         toolHandler = handler as typeof toolHandler;
@@ -58,5 +66,51 @@ describe('list-projects tool', () => {
     const result = await toolHandler({});
     expect(result.content[0].type).toBe('text');
     expect(() => JSON.parse(result.content[0].text)).not.toThrow();
+  });
+
+  describe('account mode', () => {
+    it('is API-backed: calls GET /projects (via the cache) and returns real projects with id/name/status', async () => {
+      const { getAccountModeInfo } = await import('../../../src/config.js');
+      const { getProjects } = await import('../../../src/utils/projects-cache.js');
+      (getAccountModeInfo as any).mockResolvedValue({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+      });
+      (getProjects as any).mockResolvedValue([
+        { id: 1, name: 'Backend', status: 'enabled' },
+        { id: 2, name: 'Frontend', status: 'enabled' },
+      ]);
+
+      const result = await toolHandler({});
+      const content = JSON.parse(result.content[0].text);
+
+      expect(getProjects).toHaveBeenCalledWith(
+        'acct-token',
+        'https://api.rollbar.com/api/1',
+      );
+      expect(content).toEqual([
+        { id: 1, name: 'Backend', status: 'enabled' },
+        { id: 2, name: 'Frontend', status: 'enabled' },
+      ]);
+    });
+
+    it('never returns a token field in account mode', async () => {
+      const { getAccountModeInfo } = await import('../../../src/config.js');
+      const { getProjects } = await import('../../../src/utils/projects-cache.js');
+      (getAccountModeInfo as any).mockResolvedValue({
+        active: true,
+        token: 'acct-token',
+        apiBase: 'https://api.rollbar.com/api/1',
+      });
+      (getProjects as any).mockResolvedValue([
+        { id: 1, name: 'Backend', status: 'enabled' },
+      ]);
+
+      const result = await toolHandler({});
+      const content = JSON.parse(result.content[0].text);
+
+      expect(content[0]).not.toHaveProperty('token');
+    });
   });
 });

--- a/tests/unit/tools/update-item.test.ts
+++ b/tests/unit/tools/update-item.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/api.js', () => ({
 }));
 
 vi.mock('../../../src/config.js', () => ({
+  HAS_ACCOUNT_TOKEN: false,
   PROJECTS: [
     {
       name: 'default',
@@ -18,6 +19,11 @@ vi.mock('../../../src/config.js', () => ({
   resolveProject: vi.fn(() => ({
     name: 'default',
     token: 'test-token',
+    apiBase: 'https://api.rollbar.com/api/1',
+  })),
+  resolveAuthContext: vi.fn(async () => ({
+    token: 'test-token',
+    tokenType: 'project',
     apiBase: 'https://api.rollbar.com/api/1',
   })),
   getUserAgent: (toolName: string) => `rollbar-mcp-server/test (tool: ${toolName})`,
@@ -301,6 +307,40 @@ describe('update-item tool', () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ snoozed: false })
+      }
+    );
+  });
+
+  it('should merge project_id into the JSON body in account mode (PATCH /item/{id})', async () => {
+    const { resolveAuthContext } = await import('../../../src/config.js');
+    (resolveAuthContext as any).mockResolvedValueOnce({
+      token: 'acct-token',
+      tokenType: 'account',
+      projectId: 44,
+      apiBase: 'https://api.rollbar.com/api/1',
+    });
+    const mockResponse = {
+      err: 0,
+      result: { id: 123, status: 'resolved' }
+    };
+    makeRollbarRequestMock.mockResolvedValueOnce(mockResponse);
+
+    await toolHandler({
+      itemId: 123,
+      status: 'resolved',
+      project: 'SomeProject',
+    });
+
+    expect(makeRollbarRequestMock).toHaveBeenCalledWith(
+      'https://api.rollbar.com/api/1/item/123',
+      'update-item',
+      'acct-token',
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ status: 'resolved', project_id: 44 })
       }
     );
   });

--- a/tests/unit/utils/api.test.ts
+++ b/tests/unit/utils/api.test.ts
@@ -189,5 +189,70 @@ describe('api utilities', () => {
         }
       });
     });
+
+    describe('actionable 401/403 error hints', () => {
+      it('adds an invalid/expired token hint on 401', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 401,
+          statusText: 'Unauthorized',
+          text: vi.fn().mockResolvedValueOnce('')
+        });
+
+        await expect(makeRollbarRequest(testUrl, 'get-deployments', 'test-token'))
+          .rejects.toThrow(/invalid or expired/);
+      });
+
+      it('adds an account-token-required hint on 403 against GET /projects', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          text: vi.fn().mockResolvedValueOnce('')
+        });
+
+        await expect(
+          makeRollbarRequest('https://api.rollbar.com/api/1/projects', 'list-projects', 'test-token')
+        ).rejects.toThrow(/requires an account access token/);
+      });
+
+      it('adds an update-item-specific write-scope hint on 403 for update-item', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          text: vi.fn().mockResolvedValueOnce('')
+        });
+
+        await expect(
+          makeRollbarRequest('https://api.rollbar.com/api/1/item/123', 'update-item', 'test-token')
+        ).rejects.toThrow(/write scope/);
+      });
+
+      it('adds a generic insufficient-privileges hint on 403 for other tools', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          text: vi.fn().mockResolvedValueOnce('')
+        });
+
+        await expect(
+          makeRollbarRequest('https://api.rollbar.com/api/1/deploys', 'get-deployments', 'test-token')
+        ).rejects.toThrow(/sufficient privileges/);
+      });
+
+      it('does not add a hint for non-auth error statuses', async () => {
+        fetchMock.mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          text: vi.fn().mockResolvedValueOnce('')
+        });
+
+        await expect(makeRollbarRequest(testUrl, 'get-deployments', 'test-token'))
+          .rejects.toThrow('Rollbar API error: 404 Not Found');
+      });
+    });
   });
 });

--- a/tests/unit/utils/params.test.ts
+++ b/tests/unit/utils/params.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  injectProjectIdQueryParam,
+  injectProjectIdBodyParam,
+  injectProjectIdsRepeatedQueryParam,
+} from "../../../src/utils/params.js";
+import type { AuthContext } from "../../../src/config.js";
+
+const accountAuth: AuthContext = {
+  token: "acct-token",
+  tokenType: "account",
+  projectId: 42,
+  apiBase: "https://api.rollbar.com/api/1",
+};
+
+const projectAuth: AuthContext = {
+  token: "proj-token",
+  tokenType: "project",
+  apiBase: "https://api.rollbar.com/api/1",
+};
+
+const accountAuthNoProjectId: AuthContext = {
+  token: "acct-token",
+  tokenType: "account",
+  apiBase: "https://api.rollbar.com/api/1",
+};
+
+describe("params injection helper", () => {
+  describe("injectProjectIdQueryParam", () => {
+    it("appends project_id as a query param when no existing query string (GET /deploys)", () => {
+      const url = injectProjectIdQueryParam(
+        "https://api.rollbar.com/api/1/deploys?limit=10",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/deploys?limit=10&project_id=42",
+      );
+    });
+
+    it("appends project_id with ? when url has no existing query string (GET /instance/{id})", () => {
+      const url = injectProjectIdQueryParam(
+        "https://api.rollbar.com/api/1/instance/999",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/instance/999?project_id=42",
+      );
+    });
+
+    it("appends project_id for GET /versions/{v}", () => {
+      const url = injectProjectIdQueryParam(
+        "https://api.rollbar.com/api/1/versions/abc123?environment=production",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/versions/abc123?environment=production&project_id=42",
+      );
+    });
+
+    it("appends project_id for GET /reports/top_active_items", () => {
+      const url = injectProjectIdQueryParam(
+        "https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=production&sort=occurrences",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/reports/top_active_items?hours=24&environments=production&sort=occurrences&project_id=42",
+      );
+    });
+
+    it("appends project_id for the replay path", () => {
+      const url = injectProjectIdQueryParam(
+        "https://api.rollbar.com/api/1/environment/production/session/s1/replay/r1",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/environment/production/session/s1/replay/r1?project_id=42",
+      );
+    });
+
+    it("appends project_id for GET /item?counter=", () => {
+      const url = injectProjectIdQueryParam(
+        "https://api.rollbar.com/api/1/item?counter=42",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/item?counter=42&project_id=42",
+      );
+    });
+
+    it("is a no-op passthrough in project-token mode", () => {
+      const original = "https://api.rollbar.com/api/1/deploys?limit=10";
+      const url = injectProjectIdQueryParam(original, projectAuth);
+      expect(url).toBe(original);
+    });
+
+    it("is a no-op when account mode has no resolved projectId", () => {
+      const original = "https://api.rollbar.com/api/1/deploys?limit=10";
+      const url = injectProjectIdQueryParam(original, accountAuthNoProjectId);
+      expect(url).toBe(original);
+    });
+  });
+
+  describe("injectProjectIdBodyParam", () => {
+    it("merges project_id into the JSON body for PATCH /item/{id}", () => {
+      const body = injectProjectIdBodyParam({ status: "resolved" }, accountAuth);
+      expect(body).toEqual({ status: "resolved", project_id: 42 });
+    });
+
+    it("is a no-op passthrough in project-token mode", () => {
+      const original = { status: "resolved" };
+      const body = injectProjectIdBodyParam(original, projectAuth);
+      expect(body).toEqual({ status: "resolved" });
+      expect(body).not.toHaveProperty("project_id");
+    });
+
+    it("is a no-op when account mode has no resolved projectId", () => {
+      const original = { status: "resolved" };
+      const body = injectProjectIdBodyParam(original, accountAuthNoProjectId);
+      expect(body).toEqual({ status: "resolved" });
+      expect(body).not.toHaveProperty("project_id");
+    });
+
+    it("does not mutate the original body object", () => {
+      const original = { status: "resolved" };
+      injectProjectIdBodyParam(original, accountAuth);
+      expect(original).toEqual({ status: "resolved" });
+      expect(original).not.toHaveProperty("project_id");
+    });
+  });
+
+  describe("injectProjectIdsRepeatedQueryParam (GET /items/ exception)", () => {
+    it("appends a single repeated project_ids param, not singular project_id", () => {
+      const url = injectProjectIdsRepeatedQueryParam(
+        "https://api.rollbar.com/api/1/items/?status=active",
+        accountAuth,
+      );
+      expect(url).toBe(
+        "https://api.rollbar.com/api/1/items/?status=active&project_ids=42",
+      );
+    });
+
+    it("appends with ? when there is no existing query string", () => {
+      const url = injectProjectIdsRepeatedQueryParam(
+        "https://api.rollbar.com/api/1/items/",
+        accountAuth,
+      );
+      expect(url).toBe("https://api.rollbar.com/api/1/items/?project_ids=42");
+    });
+
+    it("is a no-op passthrough in project-token mode", () => {
+      const original = "https://api.rollbar.com/api/1/items/?status=active";
+      const url = injectProjectIdsRepeatedQueryParam(original, projectAuth);
+      expect(url).toBe(original);
+    });
+
+    it("is a no-op when account mode has no resolved projectId", () => {
+      const original = "https://api.rollbar.com/api/1/items/?status=active";
+      const url = injectProjectIdsRepeatedQueryParam(
+        original,
+        accountAuthNoProjectId,
+      );
+      expect(url).toBe(original);
+    });
+
+    // Explicit regression test: this helper must NEVER produce a singular
+    // `project_id` param or a comma-joined `project_ids=1,2` — both hang for
+    // ~25s and return a 422 in production against the real Rollbar API.
+    it("REGRESSION: never produces singular project_id or comma-joined project_ids", () => {
+      const url = injectProjectIdsRepeatedQueryParam(
+        "https://api.rollbar.com/api/1/items/?status=active",
+        accountAuth,
+      );
+
+      const params = new URLSearchParams(url.split("?")[1]);
+      const projectIdsValues = params.getAll("project_ids");
+
+      // Must be the plural key with exactly one bare numeric value.
+      expect(projectIdsValues).toEqual(["42"]);
+      // Must never contain a comma (i.e. never comma-joined).
+      expect(projectIdsValues.some((v) => v.includes(","))).toBe(false);
+      // Must never also produce a singular project_id key.
+      expect(params.has("project_id")).toBe(false);
+      // The raw URL string must not contain the singular key as a substring
+      // key (guards against string-concatenation bugs that could slip a
+      // `project_id=` in alongside `project_ids=`).
+      expect(url).not.toMatch(/[?&]project_id=/);
+    });
+
+    it("REGRESSION: calling twice with two different accounts still appends repeated (not merged/deduped) params correctly per call", () => {
+      const authA: AuthContext = { ...accountAuth, projectId: 1 };
+      const urlA = injectProjectIdsRepeatedQueryParam(
+        "https://api.rollbar.com/api/1/items/",
+        authA,
+      );
+      expect(urlA).toBe("https://api.rollbar.com/api/1/items/?project_ids=1");
+      expect(urlA).not.toContain(",");
+    });
+  });
+});

--- a/tests/unit/utils/project-params.test.ts
+++ b/tests/unit/utils/project-params.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("buildProjectParam", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns an optional free-form string schema when zero projects are configured (account-token-only mode)", async () => {
+    vi.doMock("../../../src/config.js", () => ({
+      PROJECTS: [],
+      HAS_ACCOUNT_TOKEN: true,
+    }));
+    const { buildProjectParam } =
+      await import("../../../src/utils/project-params.js");
+
+    const schema = buildProjectParam();
+
+    // The whole point of this test: with no project-token entries
+    // configured, a tool call that omits `project` entirely (the normal
+    // single-enabled-project case) must still validate successfully. Before
+    // this fix, buildProjectParam() fell through to the multi-project
+    // z.enum([]) branch here, which is a required field no value can ever
+    // satisfy -- silently breaking every tool in pure account-token mode.
+    expect(schema.safeParse(undefined).success).toBe(true);
+
+    // An arbitrary project name/id (resolved dynamically against the
+    // account's GET /projects at call time, not a static config list) must
+    // also be accepted here -- there's no fixed set of names to enum over.
+    expect(schema.safeParse("AnyProjectName").success).toBe(true);
+    expect(schema.safeParse("123").success).toBe(true);
+  });
+
+  it("returns an optional string schema when exactly one project is configured", async () => {
+    vi.doMock("../../../src/config.js", () => ({
+      PROJECTS: [{ name: "default", token: "t", apiBase: "base" }],
+      HAS_ACCOUNT_TOKEN: false,
+    }));
+    const { buildProjectParam } =
+      await import("../../../src/utils/project-params.js");
+
+    const schema = buildProjectParam();
+
+    expect(schema.safeParse(undefined).success).toBe(true);
+    expect(schema.safeParse("default").success).toBe(true);
+  });
+
+  it("returns a required enum schema constrained to configured names when multiple projects are configured", async () => {
+    vi.doMock("../../../src/config.js", () => ({
+      PROJECTS: [
+        { name: "backend", token: "t1", apiBase: "base" },
+        { name: "frontend", token: "t2", apiBase: "base" },
+      ],
+      HAS_ACCOUNT_TOKEN: false,
+    }));
+    const { buildProjectParam } =
+      await import("../../../src/utils/project-params.js");
+
+    const schema = buildProjectParam();
+
+    expect(schema.safeParse("backend").success).toBe(true);
+    expect(schema.safeParse("frontend").success).toBe(true);
+    expect(schema.safeParse("unknown-project").success).toBe(false);
+    // Multi-project mode still requires an explicit project — omission is
+    // rejected here (unchanged pre-existing behavior).
+    expect(schema.safeParse(undefined).success).toBe(false);
+  });
+
+  it("returns a free-form string schema (not a static enum) when multiple projects AND an account token are configured", async () => {
+    vi.doMock("../../../src/config.js", () => ({
+      PROJECTS: [
+        { name: "backend", token: "t1", apiBase: "base" },
+        { name: "frontend", token: "t2", apiBase: "base" },
+      ],
+      HAS_ACCOUNT_TOKEN: true,
+    }));
+    const { buildProjectParam } =
+      await import("../../../src/utils/project-params.js");
+
+    const schema = buildProjectParam();
+
+    // Hybrid config: explicit project tokens for "backend"/"frontend", plus
+    // an account token that can also reach any other project on the
+    // account. Before this fix, this schema was a static z.enum(["backend",
+    // "frontend"]) that rejected any other project name at the MCP
+    // input-validation layer, before resolveAuthContext()'s working
+    // account-token fallback ever ran.
+    expect(schema.safeParse("backend").success).toBe(true);
+    expect(schema.safeParse("frontend").success).toBe(true);
+    expect(schema.safeParse("SomeOtherAccountProject").success).toBe(true);
+    expect(schema.safeParse("776050").success).toBe(true);
+    expect(schema.safeParse(undefined).success).toBe(true);
+  });
+});

--- a/tests/unit/utils/projects-cache.test.ts
+++ b/tests/unit/utils/projects-cache.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("projects-cache", () => {
+  let fetchMock: any;
+  let getProjects: any;
+  let resolveProjectId: any;
+  let __resetProjectsCacheForTests: any;
+
+  const token = "acct-token";
+  const apiBase = "https://api.rollbar.com/api/1";
+
+  function jsonResponse(body: unknown, ok = true, status = 200) {
+    return {
+      ok,
+      status,
+      statusText: ok ? "OK" : "Error",
+      json: vi.fn().mockResolvedValue(body),
+    };
+  }
+
+  beforeEach(async () => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    vi.resetModules();
+
+    const mod = await import("../../../src/utils/projects-cache.js");
+    getProjects = mod.getProjects;
+    resolveProjectId = mod.resolveProjectId;
+    __resetProjectsCacheForTests = mod.__resetProjectsCacheForTests;
+    __resetProjectsCacheForTests();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const allProjects = [
+    { id: 1, name: "Backend", status: "enabled" },
+    { id: 2, name: "Frontend", status: "enabled" },
+    { id: 3, name: "Old-Disabled", status: "disabled" },
+  ];
+
+  it("fetches GET /projects once and filters out disabled projects", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 0, result: allProjects }),
+    );
+
+    const projects = await getProjects(token, apiBase);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${apiBase}/projects`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Rollbar-Access-Token": token }),
+      }),
+    );
+    expect(projects).toHaveLength(2);
+    expect(projects.map((p: any) => p.name)).toEqual(["Backend", "Frontend"]);
+  });
+
+  it("reuses the cache on subsequent calls instead of refetching", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 0, result: allProjects }),
+    );
+
+    await getProjects(token, apiBase);
+    await getProjects(token, apiBase);
+    await getProjects(token, apiBase);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a project name to an id, case-insensitively", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 0, result: allProjects }),
+    );
+
+    const id = await resolveProjectId(token, apiBase, "backend");
+    expect(id).toBe(1);
+  });
+
+  it("passes through a numeric id string without needing a name match", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 0, result: allProjects }),
+    );
+
+    const id = await resolveProjectId(token, apiBase, "2");
+    expect(id).toBe(2);
+  });
+
+  it("refreshes the cache once on a lookup miss, then retries the match", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ err: 0, result: allProjects }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [
+            ...allProjects,
+            { id: 4, name: "NewProject", status: "enabled" },
+          ],
+        }),
+      );
+
+    // Prime the cache with the original list first.
+    await getProjects(token, apiBase);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const id = await resolveProjectId(token, apiBase, "NewProject");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(id).toBe(4);
+  });
+
+  it("throws an error listing available project names after refresh-once still misses", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ err: 0, result: allProjects }));
+
+    let thrown: Error | undefined;
+    try {
+      await resolveProjectId(token, apiBase, "DoesNotExist");
+    } catch (error) {
+      thrown = error as Error;
+    }
+
+    expect(thrown?.message).toMatch(/Unknown project "DoesNotExist"/);
+    expect(thrown?.message).toMatch(/Backend.*Frontend/);
+    // Confirms the refresh-once behavior actually happened (initial fetch +
+    // one refresh-on-miss).
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("auto-selects the single enabled project as default when no project param is given", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        err: 0,
+        result: [{ id: 7, name: "Solo", status: "enabled" }],
+      }),
+    );
+
+    const id = await resolveProjectId(token, apiBase, undefined);
+    expect(id).toBe(7);
+  });
+
+  it("throws when no project param is given and multiple projects are enabled", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 0, result: allProjects }),
+    );
+
+    await expect(resolveProjectId(token, apiBase, undefined)).rejects.toThrow(
+      /Multiple projects available/,
+    );
+  });
+
+  it("filters out disabled projects entirely from resolution", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 0, result: allProjects }),
+    );
+
+    await expect(
+      resolveProjectId(token, apiBase, "Old-Disabled"),
+    ).rejects.toThrow();
+  });
+
+  it("throws when the API responds with a non-ok status", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({}, false, 403),
+    );
+
+    await expect(getProjects(token, apiBase)).rejects.toThrow(
+      /Failed to fetch Rollbar projects/,
+    );
+  });
+
+  it("throws when the API responds with err !== 0", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ err: 1, message: "boom" }),
+    );
+
+    await expect(getProjects(token, apiBase)).rejects.toThrow(/boom/);
+  });
+
+  it("retries once when the initial cache is empty and finds a single project after refresh", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ err: 0, result: [] }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          err: 0,
+          result: [{ id: 3, name: "JustAdded", status: "enabled" }],
+        }),
+      );
+
+    const id = await resolveProjectId(token, apiBase, undefined);
+
+    expect(id).toBe(3);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws 'no enabled projects' when still empty after the refresh", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ err: 0, result: [] }));
+
+    await expect(resolveProjectId(token, apiBase, undefined)).rejects.toThrow(
+      /No enabled Rollbar projects found/,
+    );
+  });
+});

--- a/tests/unit/utils/projects-cache.test.ts
+++ b/tests/unit/utils/projects-cache.test.ts
@@ -178,6 +178,27 @@ describe("projects-cache", () => {
     await expect(getProjects(token, apiBase)).rejects.toThrow(/boom/);
   });
 
+  it("retries against the API instead of replaying a stale rejection after a failed fetch", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(jsonResponse({ err: 0, result: allProjects }));
+
+    await expect(getProjects(token, apiBase)).rejects.toThrow(
+      /network error/,
+    );
+
+    // Before the fix, the rejected fetchPromise stayed cached forever, so
+    // this lookup miss (name not found in the empty post-failure cache)
+    // would retry against that same dead rejected promise instead of
+    // hitting the API again -- account-token mode would stay broken until
+    // process restart even though the underlying issue (e.g. a transient
+    // network blip) had already cleared up.
+    const id = await resolveProjectId(token, apiBase, "Backend");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(id).toBe(1);
+  });
+
   it("retries once when the initial cache is empty and finds a single project after refresh", async () => {
     fetchMock
       .mockResolvedValueOnce(jsonResponse({ err: 0, result: [] }))


### PR DESCRIPTION
## What

One account token can now drive every tool: config accepts `ROLLBAR_ACCOUNT_ACCESS_TOKEN` (or `accountToken` in `.rollbar-mcp.json`, including an account-only config with no per-project tokens at all), projects are discovered and cached from `GET /projects`, and requests get `project_id` injected per endpoint — query param for GETs, JSON body for the `PATCH` in update-item, and repeated `project_ids=` query params for item search. Project-token configs are unchanged, and a legacy `ROLLBAR_ACCESS_TOKEN` is lazily probed once to detect whether it's actually an account token.

## Why

Customers with prompts that span multiple projects currently have to collect and configure a token per project. One account token, with per-call project selection, removes that friction and matches how account-scoped tokens actually work on the Rollbar API side.

## Details worth knowing

- The auth header is identical for both token types (`X-Rollbar-Access-Token`); project scoping happens entirely through request params, which differ by endpoint — this is why the param-building is centralized in one helper and regression-tested, especially for `GET /items/`, which only accepts *repeated* `project_ids=` params (a singular `project_id` or comma-joined list hangs ~25s then 422 in production).
- A second review pass (thanks to an independent pass from Codex) turned up several real edge cases that got fixed here too, each with its own regression test:
  - Account-token-only config files (`{ "accountToken": "..." }` alone, no `projects`/`token`) were rejected by the schema — the documented example didn't actually work.
  - `delivery="resource"` on `get-replay` could hand back a `rollbar://` link that was guaranteed to fail on read, in multi-project account-token mode — the guard was checking the wrong thing.
  - A hybrid config (explicit per-project tokens plus an account token) couldn't reach any project beyond the explicitly-listed ones, because the `project` parameter's schema was a static enum that never considered the account token.
  - A legacy `ROLLBAR_ACCESS_TOKEN` that probes as a plain project token was silently ignoring a mismatched `project` argument instead of rejecting it — a request for the wrong project name would silently get served by whatever token was configured.
- README updated to match: real token-creation steps, an account-token client example, and corrected scope guidance (`update-item` needs both read and write in account mode, since resolving the target project via `GET /projects` always happens before the `PATCH`).

## Testing

- `npm test` — 248/248 passing
- `npm run test:coverage` — 97.27% statements / 89.3% branches / 98.61% functions / 97.17% lines, above the configured 80/80/90/80 thresholds
- `npm run lint` / `npm run format` — clean
- `npm run build` — clean

Linear: ROL-1016